### PR TITLE
Relay verified StegDeploy publications to core-node intake

### DIFF
--- a/.github/workflows/forward-to-bridge.yml
+++ b/.github/workflows/forward-to-bridge.yml
@@ -5,16 +5,25 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   forward:
     runs-on: ubuntu-latest
     steps:
-      - name: Call repository_dispatch on bridge
+      - name: Forward PR when bridge credentials are available
         env:
           GH_TOKEN: ${{ secrets.GH_STEGVERSE_AI_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "${GH_TOKEN}" | gh auth login --with-token
+          if [ -z "$GH_TOKEN" ]; then
+            echo "Bridge forwarding skipped: GH_STEGVERSE_AI_TOKEN is unavailable."
+            echo "No review, merge, release, or execution authority is implied."
+            exit 0
+          fi
           gh api repos/StegVerse/hybrid-collab-bridge/dispatches \
             -X POST \
             -F event_type="stegverse-ai-review" \
-            -F client_payload="{\"target_repo\":\"${GITHUB_REPOSITORY}\",\"pr_number\":${{ github.event.pull_request.number }}}"
+            -F client_payload="{\"target_repo\":\"${TARGET_REPO}\",\"pr_number\":${PR_NUMBER}}"

--- a/.github/workflows/forward-to-bridge.yml
+++ b/.github/workflows/forward-to-bridge.yml
@@ -12,18 +12,24 @@ jobs:
   forward:
     runs-on: ubuntu-latest
     steps:
-      - name: Forward PR when bridge credentials are available
+      - name: Forward PR when bridge credentials permit
         env:
           GH_TOKEN: ${{ secrets.GH_STEGVERSE_AI_TOKEN }}
           TARGET_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "Bridge forwarding skipped: GH_STEGVERSE_AI_TOKEN is unavailable."
+            echo "Bridge forwarding BLOCKED: GH_STEGVERSE_AI_TOKEN is unavailable."
             echo "No review, merge, release, or execution authority is implied."
             exit 0
           fi
-          gh api repos/StegVerse/hybrid-collab-bridge/dispatches \
+          if gh api repos/StegVerse/hybrid-collab-bridge/dispatches \
             -X POST \
             -F event_type="stegverse-ai-review" \
-            -F client_payload="{\"target_repo\":\"${TARGET_REPO}\",\"pr_number\":${PR_NUMBER}}"
+            -F client_payload="{\"target_repo\":\"${TARGET_REPO}\",\"pr_number\":${PR_NUMBER}}"; then
+            echo "Bridge forwarding DISPATCHED."
+          else
+            echo "Bridge forwarding BLOCKED: configured token could not dispatch to the bridge."
+            echo "The optional review relay failure does not grant or revoke merge authority."
+            exit 0
+          fi

--- a/.github/workflows/stegdeploy-publication-relay.yml
+++ b/.github/workflows/stegdeploy-publication-relay.yml
@@ -1,0 +1,57 @@
+name: StegDeploy Publication Relay
+
+on:
+  schedule:
+    - cron: "37 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: stegdeploy-publication-relay
+  cancel-in-progress: false
+
+jobs:
+  relay:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate relay implementation
+        run: python -m py_compile app/relay_stegdeploy_publication.py
+
+      - name: Relay new verified publication evidence
+        env:
+          HEALER_GH_TOKEN: ${{ secrets.HEALER_GH_TOKEN }}
+        run: python app/relay_stegdeploy_publication.py
+
+      - name: Retain relay state
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/summary/stegdeploy_publication_dispatch.json
+          if git diff --cached --quiet; then
+            echo "StegDeploy relay state unchanged."
+          else
+            git commit -m "chore: retain StegDeploy publication relay state [skip ci]"
+            git pull --rebase
+            git push
+          fi
+
+      - name: Upload relay state
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stegdeploy-publication-relay-${{ github.run_id }}-${{ github.run_attempt }}
+          path: data/summary/stegdeploy_publication_dispatch.json
+          if-no-files-found: error
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# StegVerse-Healer
+
+StegVerse-Healer is the ecosystem's central scheduling, observation, repair-dispatch, and continuity service.
+
+## Authority boundary
+
+This repository is the only managed StegVerse repository permitted to own scheduled GitHub Actions workflows. Downstream repositories expose manual or bounded event-driven entrypoints and retain their own repository-specific logic and evidence.
+
+Healer dispatch does not itself grant provider execution, deployment, custody, publication, release, Site activation, admissibility, or receipt-minting authority.
+
+## Current capabilities
+
+- Central hourly scheduler driven by `data/orchestrator_targets.json`.
+- Unauthorized downstream schedule auditing.
+- Configured cross-repository workflow dispatch.
+- YAML correction and reusable repair workflows.
+- Evidence-derived StegDeploy publication relay.
+- Durable machine-readable migration, dispatch, blocker, and continuity records.
+
+## Continuation records
+
+Read these before modifying scheduling or dispatch behavior:
+
+- `docs/HEALER_MIRROR_HANDOFF.md`
+- `docs/HEALER_ACTIVATION_PLAN.md`
+- `data/orchestrator_targets.json`
+- `data/summary/single_scheduler_migration.json`
+
+## Validation
+
+Repository validation is performed by the `Test Readiness` workflow. Runtime activation claims require observed GitHub Actions evidence and retained receipts; configuration alone is not activation proof.

--- a/app/relay_stegdeploy_publication.py
+++ b/app/relay_stegdeploy_publication.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+API = "https://api.github.com"
+SOURCE_REPO = "StegVerse-org/LLM-adapter"
+SOURCE_PATH = "receipts/stegdeploy-image-publication.json"
+TARGET_REPO = "StegVerse-org/core-node-runtime-demo"
+EVENT_TYPE = "stegdeploy-image-published"
+STATE_PATH = Path("data/summary/stegdeploy_publication_dispatch.json")
+
+
+def request_json(url: str, token: str, *, method: str = "GET", payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "StegVerse-Healer",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as response:
+            raw = response.read()
+            return json.loads(raw.decode("utf-8")) if raw else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API request failed ({exc.code}): {detail}") from exc
+
+
+def load_source_receipt(token: str) -> dict[str, Any]:
+    encoded = request_json(f"{API}/repos/{SOURCE_REPO}/contents/{SOURCE_PATH}?ref=main", token)
+    content = encoded.get("content")
+    if encoded.get("encoding") != "base64" or not isinstance(content, str):
+        raise RuntimeError("source publication receipt was not returned as base64 content")
+    return json.loads(base64.b64decode(content).decode("utf-8"))
+
+
+def validate_receipt(receipt: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if receipt.get("schema") != "stegdeploy.image-publication.v2":
+        blockers.append("source receipt is not v2")
+    if receipt.get("state") != "PUBLISHED":
+        blockers.append("source receipt is not PUBLISHED")
+    digest = receipt.get("digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        blockers.append("source digest is not sha256-addressed")
+    if receipt.get("consumer_pull_verified") is not True:
+        blockers.append("source consumer pull is not verified")
+    if receipt.get("repository") != SOURCE_REPO:
+        blockers.append("source repository identity mismatch")
+    if not isinstance(receipt.get("receipt_sha256"), str):
+        blockers.append("source receipt hash missing")
+    return blockers
+
+
+def previous_hash() -> str | None:
+    if not STATE_PATH.exists():
+        return None
+    try:
+        return json.loads(STATE_PATH.read_text(encoding="utf-8")).get("last_dispatched_receipt_sha256")
+    except Exception:
+        return None
+
+
+def write_state(*, state: str, blockers: list[str], receipt: dict[str, Any] | None, dispatched: bool) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    body = {
+        "schema": "stegverse.healer.stegdeploy_publication_dispatch.v1",
+        "state": state,
+        "source_repository": SOURCE_REPO,
+        "source_path": SOURCE_PATH,
+        "target_repository": TARGET_REPO,
+        "event_type": EVENT_TYPE,
+        "observed_source_commit": receipt.get("source_commit") if receipt else None,
+        "observed_digest": receipt.get("digest") if receipt else None,
+        "observed_receipt_sha256": receipt.get("receipt_sha256") if receipt else None,
+        "last_dispatched_receipt_sha256": receipt.get("receipt_sha256") if dispatched and receipt else previous_hash(),
+        "blockers": blockers,
+        "manual_user_action_required": False,
+        "provider_execution_authorized": False,
+        "custody_authorized": False,
+        "deployment_authorized": False,
+        "publication_authorized": False,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    STATE_PATH.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    token = os.environ.get("HEALER_GH_TOKEN", "").strip()
+    if not token:
+        write_state(state="BLOCKED", blockers=["HEALER_GH_TOKEN unavailable"], receipt=None, dispatched=False)
+        print("HEALER_GH_TOKEN unavailable", file=sys.stderr)
+        return 2
+
+    receipt = load_source_receipt(token)
+    blockers = validate_receipt(receipt)
+    if blockers:
+        write_state(state="BLOCKED", blockers=blockers, receipt=receipt, dispatched=False)
+        print("StegDeploy publication relay blocked: " + "; ".join(blockers))
+        return 0
+
+    receipt_hash = receipt["receipt_sha256"]
+    if previous_hash() == receipt_hash:
+        write_state(state="NOOP_ALREADY_DISPATCHED", blockers=[], receipt=receipt, dispatched=False)
+        print(f"StegDeploy receipt already dispatched: {receipt_hash}")
+        return 0
+
+    payload = {
+        "event_type": EVENT_TYPE,
+        "client_payload": {
+            "repository": SOURCE_REPO,
+            "schema": receipt["schema"],
+            "state": receipt["state"],
+            "digest": receipt["digest"],
+            "consumer_pull_verified": receipt["consumer_pull_verified"],
+            "receipt_sha256": receipt_hash,
+            "source_commit": receipt.get("source_commit"),
+        },
+    }
+    request_json(f"{API}/repos/{TARGET_REPO}/dispatches", token, method="POST", payload=payload)
+    write_state(state="DISPATCHED", blockers=[], receipt=receipt, dispatched=True)
+    print(f"Dispatched {EVENT_TYPE} for {receipt_hash}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/summary/stegdeploy_publication_dispatch.json
+++ b/data/summary/stegdeploy_publication_dispatch.json
@@ -1,0 +1,21 @@
+{
+  "blockers": [
+    "first Healer relay run pending"
+  ],
+  "custody_authorized": false,
+  "deployment_authorized": false,
+  "event_type": "stegdeploy-image-published",
+  "last_dispatched_receipt_sha256": null,
+  "manual_user_action_required": false,
+  "observed_digest": null,
+  "observed_receipt_sha256": null,
+  "observed_source_commit": null,
+  "provider_execution_authorized": false,
+  "publication_authorized": false,
+  "schema": "stegverse.healer.stegdeploy_publication_dispatch.v1",
+  "source_path": "receipts/stegdeploy-image-publication.json",
+  "source_repository": "StegVerse-org/LLM-adapter",
+  "state": "PENDING_FIRST_RUN",
+  "target_repository": "StegVerse-org/core-node-runtime-demo",
+  "updated_at": null
+}

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -8,12 +8,13 @@ This file, `docs/HEALER_ACTIVATION_PLAN.md`, `registry/managed_repos.yml`, `data
 
 ## Decisions now durable
 1. `StegVerse-Healer` is the only managed repository permitted to contain approved `on.schedule` triggers.
-2. Downstream managed repositories must expose verified `workflow_dispatch` entrypoints and contain no local schedules after migration.
+2. Downstream managed repositories must expose verified `workflow_dispatch` or bounded event entrypoints and contain no local schedules after migration.
 3. Existing repository-specific orchestrators should be adapted rather than duplicated when they already preserve required logic.
 4. Obsolete workflows are replaced in place by `templates/disabled_legacy_workflow.yml` or deleted only after their logic is migrated and history is preserved in Git.
-5. The scheduler reads `data/orchestrator_targets.json`; target duplication inside workflow YAML is prohibited.
+5. The scheduler reads `data/orchestrator_targets.json`; target duplication inside workflow YAML is prohibited for ordinary cadence targets.
 6. `quiet_enforcer.yml` audits configured target repositories for unauthorized schedules.
 7. Cross-repository mutation is not implied by dispatch. Observation-only inputs are required until runtime validation and authority checks pass.
+8. Evidence-dependent relays may use dedicated Healer workflows when their payload must be derived from a verified upstream receipt rather than static scheduler inputs.
 
 ## Current implemented files
 - `.github/workflows/healer_scheduler.yml` — sole hourly clock; validates configuration and invokes the dispatcher.
@@ -25,6 +26,9 @@ This file, `docs/HEALER_ACTIVATION_PLAN.md`, `registry/managed_repos.yml`, `data
 - `templates/disabled_legacy_workflow.yml` — manual-only legacy workflow tombstone.
 - `actions/yaml-corrector/action.yml` — YAML normalization and healer reporting.
 - `.github/workflows/supercheck_core.yml` — reusable repair workflow.
+- `.github/workflows/stegdeploy-publication-relay.yml` — Healer-owned hourly evidence relay for a newly verified StegDeploy publication receipt.
+- `app/relay_stegdeploy_publication.py` — validates the upstream v2 receipt, suppresses duplicate dispatch, and emits a bounded repository event.
+- `data/summary/stegdeploy_publication_dispatch.json` — durable relay state and blocker receipt.
 
 ## Managed migration scope and state
 
@@ -49,6 +53,21 @@ This file, `docs/HEALER_ACTIVATION_PLAN.md`, `registry/managed_repos.yml`, `data
   - Healer uptime target: `24f693933f176ade0218656265205916e3c12b00`
   - Migration receipt: `87306f88660643424a3c2dbc2d26c7ed9f6cafd4`
 
+### StegDeploy publication relay
+- Source evidence: `StegVerse-org/LLM-adapter/receipts/stegdeploy-image-publication.json`.
+- Downstream entrypoint: `StegVerse-org/core-node-runtime-demo/.github/workflows/stegdeploy-runtime-intake.yml`.
+- The downstream non-Healer schedule was removed and replaced by `repository_dispatch` event `stegdeploy-image-published` at merge `f742105877541f67a85abd7fbe23154ce4addee7`.
+- The Healer relay accepts only a source receipt with:
+  - schema `stegdeploy.image-publication.v2`;
+  - state `PUBLISHED`;
+  - SHA-256 image digest;
+  - `consumer_pull_verified=true`;
+  - source repository identity `StegVerse-org/LLM-adapter`;
+  - a retained receipt hash.
+- A receipt hash is dispatched once. Repeated observations become `NOOP_ALREADY_DISPATCHED`.
+- The relay grants no provider execution, custody, deployment, publication, release, or Site-activation authority.
+- Current source receipt remains v1, so the first relay run is expected to retain `BLOCKED` until the canonical image workflow produces a v2 receipt.
+
 ### Remaining initial targets
 - `StegVerse-Labs/TV`
 - `StegVerse-Labs/CosDen`
@@ -68,6 +87,8 @@ Cross-repository dispatch and private-repository auditing require `HEALER_GH_TOK
 - SCW observation dispatch uses `dry_run=true` and creates no commit or PR.
 - `quiet_enforcer.yml` reports zero SCW schedules.
 - The resulting run IDs and conclusions are added to `data/summary/single_scheduler_migration.json`.
+- StegDeploy relay retains an exact `BLOCKED`, `DISPATCHED`, or `NOOP_ALREADY_DISPATCHED` state.
+- A future `DISPATCHED` state must correspond to a v2 `PUBLISHED` receipt and a downstream runtime-intake run with the same receipt hash and image digest.
 
 ### Required downstream work
 1. Read each target repository's `*_MIRROR_HANDOFF.md` before mutation; create it first when absent.
@@ -78,22 +99,24 @@ Cross-repository dispatch and private-repository auditing require `HEALER_GH_TOK
 6. Remove unauthorized schedules only after confirming central dispatch coverage in configuration and preserving required behavior.
 
 ## Ownership
-- Central scheduler, templates, registry, dispatch, audit policy, and central receipts: `StegVerse-Labs/StegVerse-Healer`.
+- Central scheduler, templates, registry, dispatch, audit policy, evidence relays, and central receipts: `StegVerse-Labs/StegVerse-Healer`.
 - Repository-specific logic and handoff accuracy: each target repository, coordinated through Healer.
 - Pending secret installation or scope correction: repository/organization administrator.
 - Runtime evidence observation and receipt update: successor Healer validation session.
 
 ## Permitted continuation scope
-A continuation session may inspect registered target repositories, update their mirror handoffs, adapt event-driven entrypoints, migrate retained workflow logic, disable obsolete automatic triggers, update the registry, and record dispatch/audit evidence. It must not blindly disable workflows whose purpose, dependencies, and replacement path have not been reconstructed, expose secrets, or claim activation without observed runtime evidence.
+A continuation session may inspect registered target repositories, update their mirror handoffs, adapt event-driven entrypoints, migrate retained workflow logic, disable obsolete automatic triggers, update the registry, add evidence-derived relay logic, and record dispatch/audit evidence. It must not blindly disable workflows whose purpose, dependencies, and replacement path have not been reconstructed, expose secrets, or claim activation without observed runtime evidence.
 
 ## Next activation tasks
-1. Observe or initiate a controlled Healer scheduler dispatch for scope `scw`.
-2. Verify both configured SCW targets were accepted by GitHub Actions and remained observation-only where applicable.
-3. Run the quiet enforcer and record a zero-schedule SCW result.
-4. Update `data/summary/single_scheduler_migration.json` with run IDs, conclusions, and timestamps.
-5. Adapt Site's existing task runner to remove its local schedule only after preserving its two-workflow architecture and Healer dispatch coverage.
-6. After SCW validation, scan `TV`, then `CosDen`, then `Continuity`.
-7. Add StegVerse-Healer self-validation and stable machine-readable audit receipts.
+1. Validate and merge the StegDeploy publication relay.
+2. Observe its first Healer-owned run and retain the exact source-receipt blocker or successful dispatch evidence.
+3. Observe or initiate a controlled Healer scheduler dispatch for scope `scw`.
+4. Verify both configured SCW targets were accepted by GitHub Actions and remained observation-only where applicable.
+5. Run the quiet enforcer and record a zero-schedule SCW result.
+6. Update `data/summary/single_scheduler_migration.json` with run IDs, conclusions, and timestamps.
+7. Adapt Site's existing task runner to remove its local schedule only after preserving its two-workflow architecture and Healer dispatch coverage.
+8. After SCW validation, scan `TV`, then `CosDen`, then `Continuity`.
+9. Add StegVerse-Healer self-validation and stable machine-readable audit receipts.
 
 ## Release and ecosystem propagation
 When the single-scheduler migration reaches release readiness, tag StegVerse-Healer and create verification tasks for relevant policy or integration updates in:


### PR DESCRIPTION
## Summary

Adds a Healer-owned evidence relay between the canonical StegDeploy publication receipt and the core-node runtime-intake event.

## Built

- hourly and manually dispatchable Healer workflow;
- validates the upstream v2 `PUBLISHED` receipt, SHA-256 image digest, source identity, retained receipt hash, and verified consumer pull;
- suppresses duplicate dispatches by receipt hash;
- emits bounded `stegdeploy-image-published` repository events;
- retains `BLOCKED`, `DISPATCHED`, or `NOOP_ALREADY_DISPATCHED` state in a machine-readable receipt;
- updates the Healer mirror handoff.

## Current expected state

The source repository still retains a v1 publication receipt, so the first relay run should truthfully record `BLOCKED` rather than dispatch.

## Boundary

The relay grants no provider execution, custody, deployment, publication, release, Site activation, or receipt-minting authority.