### PR TITLE
Remediate stale StegDeploy publication receipts

### DIFF
--- a/app/relay_stegdeploy_publication.py
+++ b/app/relay_stegdeploy_publication.py
@@ -14,6 +14,7 @@ from typing import Any
 API = "https://api.github.com"
 SOURCE_REPO = "StegVerse-org/LLM-adapter"
 SOURCE_PATH = "receipts/stegdeploy-image-publication.json"
+SOURCE_WORKFLOW = "stegdeploy-image.yml"
 TARGET_REPO = "StegVerse-org/core-node-runtime-demo"
 EVENT_TYPE = "stegdeploy-image-published"
 STATE_PATH = Path("data/summary/stegdeploy_publication_dispatch.json")
@@ -68,28 +69,53 @@ def validate_receipt(receipt: dict[str, Any]) -> list[str]:
     return blockers
 
 
-def previous_hash() -> str | None:
+def load_previous_state() -> dict[str, Any]:
     if not STATE_PATH.exists():
-        return None
+        return {}
     try:
-        return json.loads(STATE_PATH.read_text(encoding="utf-8")).get("last_dispatched_receipt_sha256")
+        value = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
     except Exception:
-        return None
+        return {}
 
 
-def write_state(*, state: str, blockers: list[str], receipt: dict[str, Any] | None, dispatched: bool) -> None:
+def dispatch_publication_workflow(token: str) -> None:
+    request_json(
+        f"{API}/repos/{SOURCE_REPO}/actions/workflows/{SOURCE_WORKFLOW}/dispatches",
+        token,
+        method="POST",
+        payload={"ref": "main"},
+    )
+
+
+def write_state(
+    *,
+    state: str,
+    blockers: list[str],
+    receipt: dict[str, Any] | None,
+    dispatched: bool,
+    remediation_dispatched: bool = False,
+) -> None:
     STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    previous = load_previous_state()
+    source_commit = receipt.get("source_commit") if receipt else None
     body = {
-        "schema": "stegverse.healer.stegdeploy_publication_dispatch.v1",
+        "schema": "stegverse.healer.stegdeploy_publication_dispatch.v2",
         "state": state,
         "source_repository": SOURCE_REPO,
         "source_path": SOURCE_PATH,
+        "source_workflow": SOURCE_WORKFLOW,
         "target_repository": TARGET_REPO,
         "event_type": EVENT_TYPE,
-        "observed_source_commit": receipt.get("source_commit") if receipt else None,
+        "observed_source_commit": source_commit,
         "observed_digest": receipt.get("digest") if receipt else None,
         "observed_receipt_sha256": receipt.get("receipt_sha256") if receipt else None,
-        "last_dispatched_receipt_sha256": receipt.get("receipt_sha256") if dispatched and receipt else previous_hash(),
+        "last_dispatched_receipt_sha256": (
+            receipt.get("receipt_sha256") if dispatched and receipt else previous.get("last_dispatched_receipt_sha256")
+        ),
+        "last_remediation_source_commit": (
+            source_commit if remediation_dispatched else previous.get("last_remediation_source_commit")
+        ),
         "blockers": blockers,
         "manual_user_action_required": False,
         "provider_execution_authorized": False,
@@ -111,12 +137,35 @@ def main() -> int:
     receipt = load_source_receipt(token)
     blockers = validate_receipt(receipt)
     if blockers:
-        write_state(state="BLOCKED", blockers=blockers, receipt=receipt, dispatched=False)
+        previous = load_previous_state()
+        source_commit = receipt.get("source_commit")
+        stale_contract = receipt.get("schema") != "stegdeploy.image-publication.v2"
+        already_requested = bool(source_commit) and previous.get("last_remediation_source_commit") == source_commit
+        if stale_contract and not already_requested:
+            try:
+                dispatch_publication_workflow(token)
+            except Exception as exc:
+                blockers = [*blockers, f"publication remediation dispatch failed: {exc}"]
+                write_state(state="BLOCKED", blockers=blockers, receipt=receipt, dispatched=False)
+                print("StegDeploy publication remediation dispatch failed", file=sys.stderr)
+                return 1
+            write_state(
+                state="REMEDIATION_DISPATCHED",
+                blockers=blockers,
+                receipt=receipt,
+                dispatched=False,
+                remediation_dispatched=True,
+            )
+            print(f"Requested canonical StegDeploy publication workflow for stale receipt source {source_commit}")
+            return 0
+
+        state = "BLOCKED_REMEDIATION_PENDING" if stale_contract and already_requested else "BLOCKED"
+        write_state(state=state, blockers=blockers, receipt=receipt, dispatched=False)
         print("StegDeploy publication relay blocked: " + "; ".join(blockers))
         return 0
 
     receipt_hash = receipt["receipt_sha256"]
-    if previous_hash() == receipt_hash:
+    if load_previous_state().get("last_dispatched_receipt_sha256") == receipt_hash:
         write_state(state="NOOP_ALREADY_DISPATCHED", blockers=[], receipt=receipt, dispatched=False)
         print(f"StegDeploy receipt already dispatched: {receipt_hash}")
         return 0

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -15,6 +15,7 @@ This file, `docs/HEALER_ACTIVATION_PLAN.md`, `registry/managed_repos.yml`, `data
 6. `quiet_enforcer.yml` audits configured target repositories for unauthorized schedules.
 7. Cross-repository mutation is not implied by dispatch. Observation-only inputs are required until runtime validation and authority checks pass.
 8. Evidence-dependent relays may use dedicated Healer workflows when their payload must be derived from a verified upstream receipt rather than static scheduler inputs.
+9. A stale upstream receipt may trigger one deduplicated remediation dispatch to the canonical source workflow. Repeated hourly runs must not create an unbounded dispatch loop.
 
 ## Current implemented files
 - `.github/workflows/healer_scheduler.yml` — sole hourly clock; validates configuration and invokes the dispatcher.
@@ -26,9 +27,9 @@ This file, `docs/HEALER_ACTIVATION_PLAN.md`, `registry/managed_repos.yml`, `data
 - `templates/disabled_legacy_workflow.yml` — manual-only legacy workflow tombstone.
 - `actions/yaml-corrector/action.yml` — YAML normalization and healer reporting.
 - `.github/workflows/supercheck_core.yml` — reusable repair workflow.
-- `.github/workflows/stegdeploy-publication-relay.yml` — Healer-owned hourly evidence relay for a newly verified StegDeploy publication receipt.
-- `app/relay_stegdeploy_publication.py` — validates the upstream v2 receipt, suppresses duplicate dispatch, and emits a bounded repository event.
-- `data/summary/stegdeploy_publication_dispatch.json` — durable relay state and blocker receipt.
+- `.github/workflows/stegdeploy-publication-relay.yml` — Healer-owned hourly evidence relay for verified StegDeploy publication evidence.
+- `app/relay_stegdeploy_publication.py` — validates v2 publication evidence, emits bounded consumer events, and requests one canonical remediation run when the retained receipt is stale.
+- `data/summary/stegdeploy_publication_dispatch.json` — durable relay, remediation, blocker, and duplicate-suppression state.
 
 ## Managed migration scope and state
 
@@ -40,10 +41,7 @@ This file, `docs/HEALER_ACTIVATION_PLAN.md`, `registry/managed_repos.yml`, `data
 ### SCW
 - `.github/workflows/scw_orchestrator.yml` and `.github/workflows/uptime.yml` were fully inspected.
 - Both local `schedule:` triggers were removed while retaining their operational logic.
-- Healer now dispatches `scw_orchestrator.yml` hourly in observation mode using:
-  - `cmd=org-scan`
-  - `orgs=StegVerse-Labs`
-  - `dry_run=true`
+- Healer now dispatches `scw_orchestrator.yml` hourly in observation mode using `cmd=org-scan`, `orgs=StegVerse-Labs`, and `dry_run=true`.
 - Healer also dispatches `uptime.yml` through the same central hourly clock.
 - Runtime validation is pending; configuration does not claim successful dispatch or restored monitoring until Actions evidence is observed.
 - Durable evidence commits:
@@ -55,18 +53,15 @@ This file, `docs/HEALER_ACTIVATION_PLAN.md`, `registry/managed_repos.yml`, `data
 
 ### StegDeploy publication relay
 - Source evidence: `StegVerse-org/LLM-adapter/receipts/stegdeploy-image-publication.json`.
+- Source workflow: `StegVerse-org/LLM-adapter/.github/workflows/stegdeploy-image.yml`.
 - Downstream entrypoint: `StegVerse-org/core-node-runtime-demo/.github/workflows/stegdeploy-runtime-intake.yml`.
-- The downstream non-Healer schedule was removed and replaced by `repository_dispatch` event `stegdeploy-image-published` at merge `f742105877541f67a85abd7fbe23154ce4addee7`.
-- The Healer relay accepts only a source receipt with:
-  - schema `stegdeploy.image-publication.v2`;
-  - state `PUBLISHED`;
-  - SHA-256 image digest;
-  - `consumer_pull_verified=true`;
-  - source repository identity `StegVerse-org/LLM-adapter`;
-  - a retained receipt hash.
-- A receipt hash is dispatched once. Repeated observations become `NOOP_ALREADY_DISPATCHED`.
-- The relay grants no provider execution, custody, deployment, publication, release, or Site-activation authority.
-- Current source receipt remains v1, so the first relay run is expected to retain `BLOCKED` until the canonical image workflow produces a v2 receipt.
+- The downstream non-Healer schedule was replaced by `repository_dispatch` event `stegdeploy-image-published` at merge `f742105877541f67a85abd7fbe23154ce4addee7`.
+- The relay accepts only schema `stegdeploy.image-publication.v2`, state `PUBLISHED`, a SHA-256 digest, `consumer_pull_verified=true`, the canonical source repository identity, and a retained receipt hash.
+- A publication receipt hash is dispatched once. Repeated observations become `NOOP_ALREADY_DISPATCHED`.
+- The observed source receipt remains v1 after the main-branch trigger merge. The relay has truthfully retained `BLOCKED` with exact blockers.
+- The remediation repair requests `stegdeploy-image.yml` through `workflow_dispatch` once for each stale source commit, records `REMEDIATION_DISPATCHED`, and then records `BLOCKED_REMEDIATION_PENDING` until the source receipt changes.
+- Remediation does not fabricate publication evidence and does not dispatch the consumer event unless a valid v2 `PUBLISHED` receipt appears.
+- The relay grants no provider execution, custody, deployment, publication, release, Site-activation, admissibility, or receipt-minting authority.
 
 ### Remaining initial targets
 - `StegVerse-Labs/TV`
@@ -78,16 +73,15 @@ These remain disabled in the dispatch registry until their handoffs, workflow de
 ## Discovered tasks and blockers
 
 ### Authentication blocker
-Cross-repository dispatch and private-repository auditing require `HEALER_GH_TOKEN` with repository access and Actions read/write plus Contents read. The token value is never stored in this repository; its presence and scope must be validated through a controlled run.
+Cross-repository dispatch and private-repository auditing require `HEALER_GH_TOKEN` with repository access, Actions read/write, and Contents read. The token value is never stored in this repository; its presence and scope must be validated through controlled runs.
 
 ### Runtime validation requirements
 - Controlled Healer dispatch of SCW orchestrator succeeds.
 - Controlled Healer dispatch of SCW uptime succeeds.
-- SCW job summaries show `workflow_dispatch` authority and Healer scheduling authority.
-- SCW observation dispatch uses `dry_run=true` and creates no commit or PR.
+- SCW observation dispatch remains `dry_run=true` and creates no commit or PR.
 - `quiet_enforcer.yml` reports zero SCW schedules.
-- The resulting run IDs and conclusions are added to `data/summary/single_scheduler_migration.json`.
-- StegDeploy relay retains an exact `BLOCKED`, `DISPATCHED`, or `NOOP_ALREADY_DISPATCHED` state.
+- StegDeploy relay retains an exact `BLOCKED`, `REMEDIATION_DISPATCHED`, `BLOCKED_REMEDIATION_PENDING`, `DISPATCHED`, or `NOOP_ALREADY_DISPATCHED` state.
+- A `REMEDIATION_DISPATCHED` state must identify the stale source commit and must not repeat for that same commit.
 - A future `DISPATCHED` state must correspond to a v2 `PUBLISHED` receipt and a downstream runtime-intake run with the same receipt hash and image digest.
 
 ### Required downstream work
@@ -96,34 +90,29 @@ Cross-repository dispatch and private-repository auditing require `HEALER_GH_TOK
 3. Classify each automatic workflow as retained logic, migrated logic, disabled legacy logic, or prohibited duplicate schedule.
 4. Adapt a verified existing entrypoint where possible; install the universal orchestrator only when no suitable repository-specific entrypoint exists.
 5. Replace obsolete workflow contents with the disabled stub only after recording the original path and migration mapping in the repo handoff.
-6. Remove unauthorized schedules only after confirming central dispatch coverage in configuration and preserving required behavior.
+6. Remove unauthorized schedules only after confirming central dispatch coverage and preserving required behavior.
 
 ## Ownership
-- Central scheduler, templates, registry, dispatch, audit policy, evidence relays, and central receipts: `StegVerse-Labs/StegVerse-Healer`.
+- Central scheduler, templates, registry, dispatch, audit policy, evidence relays, remediation dispatch, and central receipts: `StegVerse-Labs/StegVerse-Healer`.
 - Repository-specific logic and handoff accuracy: each target repository, coordinated through Healer.
 - Pending secret installation or scope correction: repository/organization administrator.
 - Runtime evidence observation and receipt update: successor Healer validation session.
 
 ## Permitted continuation scope
-A continuation session may inspect registered target repositories, update their mirror handoffs, adapt event-driven entrypoints, migrate retained workflow logic, disable obsolete automatic triggers, update the registry, add evidence-derived relay logic, and record dispatch/audit evidence. It must not blindly disable workflows whose purpose, dependencies, and replacement path have not been reconstructed, expose secrets, or claim activation without observed runtime evidence.
+A continuation session may inspect registered target repositories, update their mirror handoffs, adapt event-driven entrypoints, migrate retained workflow logic, disable obsolete automatic triggers, update the registry, add evidence-derived relay and bounded remediation logic, and record dispatch/audit evidence. It must not blindly disable workflows, expose secrets, create unbounded retry loops, or claim activation without observed runtime evidence.
 
 ## Next activation tasks
-1. Validate and merge the StegDeploy publication relay.
-2. Observe its first Healer-owned run and retain the exact source-receipt blocker or successful dispatch evidence.
-3. Observe or initiate a controlled Healer scheduler dispatch for scope `scw`.
-4. Verify both configured SCW targets were accepted by GitHub Actions and remained observation-only where applicable.
-5. Run the quiet enforcer and record a zero-schedule SCW result.
-6. Update `data/summary/single_scheduler_migration.json` with run IDs, conclusions, and timestamps.
-7. Adapt Site's existing task runner to remove its local schedule only after preserving its two-workflow architecture and Healer dispatch coverage.
-8. After SCW validation, scan `TV`, then `CosDen`, then `Continuity`.
-9. Add StegVerse-Healer self-validation and stable machine-readable audit receipts.
+1. Validate and merge the bounded StegDeploy remediation repair.
+2. Observe the first Healer run and retain whether the source workflow dispatch was accepted.
+3. Observe the resulting canonical v2 `PUBLISHED` or exact `BLOCKED` source receipt.
+4. If published, verify the downstream runtime-intake receipt matches the source receipt hash and image digest.
+5. Continue SCW controlled dispatch and quiet-enforcer validation.
+6. Adapt Site's existing task runner only after preserving its two-workflow architecture and Healer coverage.
+7. After SCW validation, scan `TV`, then `CosDen`, then `Continuity`.
+8. Add StegVerse-Healer self-validation and stable machine-readable audit receipts.
 
 ## Release and ecosystem propagation
-When the single-scheduler migration reaches release readiness, tag StegVerse-Healer and create verification tasks for relevant policy or integration updates in:
-- `StegVerse-Labs/Site`
-- `GCAT-BCAT-Engine/Publisher`
-- `StegVerse-Labs/admissibility-wiki`
-- `StegVerse-Labs/stegguardian-wiki`
+When the single-scheduler migration reaches release readiness, tag StegVerse-Healer and create verification tasks for relevant policy or integration updates in `StegVerse-Labs/Site`, `GCAT-BCAT-Engine/Publisher`, `StegVerse-Labs/admissibility-wiki`, and `StegVerse-Labs/stegguardian-wiki`.
 
 ## Done condition
-Activation is complete when all registered targets are dispatchable through Healer, contain no unauthorized schedules, use real repository adapters or verified existing entrypoints rather than placeholder scaffolding, preserve repo-local handoffs, and produce non-failing execution or intentional no-op receipts without manual reconstruction.
+Activation is complete when all registered targets are dispatchable through Healer, contain no unauthorized schedules, use verified repository adapters or existing entrypoints, preserve repo-local handoffs, and produce non-failing execution or intentional no-op receipts without manual reconstruction.


### PR DESCRIPTION
## Summary

Extends the Healer-owned StegDeploy relay so a stale retained publication receipt can trigger one bounded canonical source-workflow remediation run.

## Built

- detects the still-retained v1 publication contract;
- dispatches `StegVerse-org/LLM-adapter/.github/workflows/stegdeploy-image.yml` through `workflow_dispatch`;
- deduplicates remediation by stale source commit;
- records `REMEDIATION_DISPATCHED` or `BLOCKED_REMEDIATION_PENDING` rather than creating an hourly retry loop;
- preserves the existing requirement for a verified v2 `PUBLISHED` receipt before downstream core-node dispatch;
- upgrades the relay state receipt to v2 and updates the authoritative Healer handoff.

## Current evidence

The observed source receipt remains v1 and the existing relay receipt is correctly `BLOCKED`. This repair does not claim publication or compatibility; it creates the next machine-owned attempt and retains its exact result.

## Authority boundary

No provider execution, custody, deployment, publication, release, Site activation, admissibility, or receipt-minting authority is granted.