### PR TITLE
Consolidate bounded remediation and federal-plus security policy

### DIFF
--- a/app/relay_stegdeploy_publication.py
+++ b/app/relay_stegdeploy_publication.py
@@ -14,6 +14,7 @@ from typing import Any
 API = "https://api.github.com"
 SOURCE_REPO = "StegVerse-org/LLM-adapter"
 SOURCE_PATH = "receipts/stegdeploy-image-publication.json"
+SOURCE_WORKFLOW = "stegdeploy-image.yml"
 TARGET_REPO = "StegVerse-org/core-node-runtime-demo"
 EVENT_TYPE = "stegdeploy-image-published"
 STATE_PATH = Path("data/summary/stegdeploy_publication_dispatch.json")
@@ -21,18 +22,13 @@ STATE_PATH = Path("data/summary/stegdeploy_publication_dispatch.json")
 
 def request_json(url: str, token: str, *, method: str = "GET", payload: dict[str, Any] | None = None) -> dict[str, Any]:
     data = None if payload is None else json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        method=method,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "Content-Type": "application/json",
-            "User-Agent": "StegVerse-Healer",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
+    req = urllib.request.Request(url, data=data, method=method, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "User-Agent": "StegVerse-Healer",
+        "X-GitHub-Api-Version": "2022-11-28",
+    })
     try:
         with urllib.request.urlopen(req) as response:
             raw = response.read()
@@ -52,44 +48,45 @@ def load_source_receipt(token: str) -> dict[str, Any]:
 
 def validate_receipt(receipt: dict[str, Any]) -> list[str]:
     blockers: list[str] = []
-    if receipt.get("schema") != "stegdeploy.image-publication.v2":
-        blockers.append("source receipt is not v2")
-    if receipt.get("state") != "PUBLISHED":
-        blockers.append("source receipt is not PUBLISHED")
+    if receipt.get("schema") != "stegdeploy.image-publication.v2": blockers.append("source receipt is not v2")
+    if receipt.get("state") != "PUBLISHED": blockers.append("source receipt is not PUBLISHED")
     digest = receipt.get("digest")
-    if not isinstance(digest, str) or not digest.startswith("sha256:"):
-        blockers.append("source digest is not sha256-addressed")
-    if receipt.get("consumer_pull_verified") is not True:
-        blockers.append("source consumer pull is not verified")
-    if receipt.get("repository") != SOURCE_REPO:
-        blockers.append("source repository identity mismatch")
-    if not isinstance(receipt.get("receipt_sha256"), str):
-        blockers.append("source receipt hash missing")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"): blockers.append("source digest is not sha256-addressed")
+    if receipt.get("consumer_pull_verified") is not True: blockers.append("source consumer pull is not verified")
+    if receipt.get("repository") != SOURCE_REPO: blockers.append("source repository identity mismatch")
+    if not isinstance(receipt.get("receipt_sha256"), str): blockers.append("source receipt hash missing")
     return blockers
 
 
-def previous_hash() -> str | None:
-    if not STATE_PATH.exists():
-        return None
+def load_previous_state() -> dict[str, Any]:
+    if not STATE_PATH.exists(): return {}
     try:
-        return json.loads(STATE_PATH.read_text(encoding="utf-8")).get("last_dispatched_receipt_sha256")
+        value = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
     except Exception:
-        return None
+        return {}
 
 
-def write_state(*, state: str, blockers: list[str], receipt: dict[str, Any] | None, dispatched: bool) -> None:
-    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+def dispatch_publication_workflow(token: str) -> None:
+    request_json(f"{API}/repos/{SOURCE_REPO}/actions/workflows/{SOURCE_WORKFLOW}/dispatches", token, method="POST", payload={"ref": "main"})
+
+
+def write_state(*, state: str, blockers: list[str], receipt: dict[str, Any] | None, dispatched: bool, remediation_dispatched: bool = False) -> None:
+    previous = load_previous_state()
+    source_commit = receipt.get("source_commit") if receipt else None
     body = {
-        "schema": "stegverse.healer.stegdeploy_publication_dispatch.v1",
+        "schema": "stegverse.healer.stegdeploy_publication_dispatch.v2",
         "state": state,
         "source_repository": SOURCE_REPO,
         "source_path": SOURCE_PATH,
+        "source_workflow": SOURCE_WORKFLOW,
         "target_repository": TARGET_REPO,
         "event_type": EVENT_TYPE,
-        "observed_source_commit": receipt.get("source_commit") if receipt else None,
+        "observed_source_commit": source_commit,
         "observed_digest": receipt.get("digest") if receipt else None,
         "observed_receipt_sha256": receipt.get("receipt_sha256") if receipt else None,
-        "last_dispatched_receipt_sha256": receipt.get("receipt_sha256") if dispatched and receipt else previous_hash(),
+        "last_dispatched_receipt_sha256": receipt.get("receipt_sha256") if dispatched and receipt else previous.get("last_dispatched_receipt_sha256"),
+        "last_remediation_source_commit": source_commit if remediation_dispatched else previous.get("last_remediation_source_commit"),
         "blockers": blockers,
         "manual_user_action_required": False,
         "provider_execution_authorized": False,
@@ -98,6 +95,7 @@ def write_state(*, state: str, blockers: list[str], receipt: dict[str, Any] | No
         "publication_authorized": False,
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATE_PATH.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
@@ -105,37 +103,40 @@ def main() -> int:
     token = os.environ.get("HEALER_GH_TOKEN", "").strip()
     if not token:
         write_state(state="BLOCKED", blockers=["HEALER_GH_TOKEN unavailable"], receipt=None, dispatched=False)
-        print("HEALER_GH_TOKEN unavailable", file=sys.stderr)
         return 2
-
     receipt = load_source_receipt(token)
     blockers = validate_receipt(receipt)
     if blockers:
-        write_state(state="BLOCKED", blockers=blockers, receipt=receipt, dispatched=False)
-        print("StegDeploy publication relay blocked: " + "; ".join(blockers))
+        previous = load_previous_state()
+        source_commit = receipt.get("source_commit")
+        stale_contract = receipt.get("schema") != "stegdeploy.image-publication.v2"
+        already_requested = bool(source_commit) and previous.get("last_remediation_source_commit") == source_commit
+        if stale_contract and not already_requested:
+            try:
+                dispatch_publication_workflow(token)
+            except Exception as exc:
+                blockers = [*blockers, f"publication remediation dispatch failed: {exc}"]
+                write_state(state="BLOCKED", blockers=blockers, receipt=receipt, dispatched=False)
+                return 1
+            write_state(state="REMEDIATION_DISPATCHED", blockers=blockers, receipt=receipt, dispatched=False, remediation_dispatched=True)
+            return 0
+        write_state(state="BLOCKED_REMEDIATION_PENDING" if stale_contract and already_requested else "BLOCKED", blockers=blockers, receipt=receipt, dispatched=False)
         return 0
-
     receipt_hash = receipt["receipt_sha256"]
-    if previous_hash() == receipt_hash:
+    if load_previous_state().get("last_dispatched_receipt_sha256") == receipt_hash:
         write_state(state="NOOP_ALREADY_DISPATCHED", blockers=[], receipt=receipt, dispatched=False)
-        print(f"StegDeploy receipt already dispatched: {receipt_hash}")
         return 0
-
-    payload = {
-        "event_type": EVENT_TYPE,
-        "client_payload": {
-            "repository": SOURCE_REPO,
-            "schema": receipt["schema"],
-            "state": receipt["state"],
-            "digest": receipt["digest"],
-            "consumer_pull_verified": receipt["consumer_pull_verified"],
-            "receipt_sha256": receipt_hash,
-            "source_commit": receipt.get("source_commit"),
-        },
-    }
+    payload = {"event_type": EVENT_TYPE, "client_payload": {
+        "repository": SOURCE_REPO,
+        "schema": receipt["schema"],
+        "state": receipt["state"],
+        "digest": receipt["digest"],
+        "consumer_pull_verified": receipt["consumer_pull_verified"],
+        "receipt_sha256": receipt_hash,
+        "source_commit": receipt.get("source_commit"),
+    }}
     request_json(f"{API}/repos/{TARGET_REPO}/dispatches", token, method="POST", payload=payload)
     write_state(state="DISPATCHED", blockers=[], receipt=receipt, dispatched=True)
-    print(f"Dispatched {EVENT_TYPE} for {receipt_hash}")
     return 0
 
 

--- a/data/session_consolidation/federal_plus_security_requirement.json
+++ b/data/session_consolidation/federal_plus_security_requirement.json
@@ -1,0 +1,32 @@
+{
+  "schema": "stegverse.session-requirement-transfer.v1",
+  "requirement_id": "SV-SEC-FEDERAL-PLUS-001",
+  "originating_session_goal": "Any security measures required by the federal government are the minimum requirement; StegVerse should exceed that requirement.",
+  "canonical_owner": "StegVerse-Labs/StegVerse-Healer",
+  "canonical_policy": "docs/SECURITY_BASELINE.md",
+  "claim_state": "MERGED_INTO_CANONICAL_WORKSTREAM",
+  "implementation_state": "POLICY_INSTALLED",
+  "validation_state": "REPOSITORY_VALIDATION_PENDING",
+  "integration_state": "APPLIED_TO_STEGDEPLOY_RELAY_CONTROLS",
+  "requirements": [
+    "Select and record the applicable federal baseline per system and deployment.",
+    "Treat the applicable baseline as a floor, not a ceiling.",
+    "Require stronger controls where feasible and evidence-supported.",
+    "Fail closed when baseline selection, control evidence, or validation is missing.",
+    "Do not claim certification or compliance without exact scope and inspectable evidence."
+  ],
+  "machine_owned_continuation": {
+    "owner": "StegVerse-Labs/StegVerse-Healer repository validation and release gates",
+    "release_condition": "Security baseline policy is merged, referenced by the canonical continuation path, and enforced by repository-specific release gates.",
+    "next_action": "Validate and merge the remediation/security consolidation pull request, then propagate the policy only through repository-owned handoffs and release gates."
+  },
+  "authority_boundaries": {
+    "provider_execution_authorized": false,
+    "deployment_authorized": false,
+    "custody_authorized": false,
+    "publication_authorized": false,
+    "certification_asserted": false
+  },
+  "archive_dependency": false,
+  "canonical_continuation": "StegVerse-Labs/StegVerse-Healer/docs/SECURITY_BASELINE.md"
+}

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -1,0 +1,30 @@
+# StegVerse Federal-Plus Security Baseline
+
+## Policy
+
+Applicable United States federal cybersecurity requirements are the minimum acceptable floor for StegVerse systems. StegVerse controls must meet or exceed the applicable baseline, remain fail-closed when evidence is missing, and avoid claiming compliance or certification without directly inspectable validation evidence.
+
+## Required control posture
+
+1. Determine the applicable federal baseline for each system, data type, deployment, customer, and operating jurisdiction before activation.
+2. Record the selected baseline, version, applicability decision, evidence sources, exceptions, and compensating controls in repository-owned records.
+3. Implement stronger controls where technically and operationally feasible, including least privilege, phishing-resistant authentication, cryptographic provenance, immutable evidence, separation of reasoning from execution, bounded dispatch, deterministic receipts, duplicate-execution prevention, tamper detection, recovery, and independent verification.
+4. Treat federal requirements as minimums, not maximums. A control may not be weakened merely because a lower baseline would satisfy a procurement or compliance threshold.
+5. Missing, stale, contradictory, or unverifiable evidence must produce `BLOCKED`, `REVIEW_REQUIRED`, or `FAILED`; it must never silently become `COMPLETE`.
+6. Compliance statements require an identified framework, version, scope, assessor or validation path, evidence location, and expiration or reassessment condition.
+7. Security controls do not themselves grant provider execution, deployment, custody, publication, release, admissibility, or activation authority.
+
+## Enforcement ownership
+
+- Canonical policy owner: `StegVerse-Labs/StegVerse-Healer` for scheduler, automation, evidence, and continuation controls.
+- Repository owners: implement and validate repository-specific controls in their own handoffs and workflows.
+- Release gates: prohibit activation when applicable baseline selection, evidence, or stronger-control justification is absent.
+- Machine observers: retain exact control and validation receipts and expose machine-observable release conditions.
+
+## Current application
+
+The StegDeploy publication relay exceeds a simple scheduled check by requiring a verified v2 publication receipt, SHA-256 digest, consumer pull verification, source identity, duplicate suppression, bounded remediation, and fail-closed state retention before downstream dispatch.
+
+## Authority boundary
+
+This document is an engineering policy and control requirement. It does not assert FedRAMP, FISMA, NIST, CMMC, DoD, agency ATO, or other certification. Certification or compliance may be claimed only when the exact applicable framework and evidence have been independently validated and retained.


### PR DESCRIPTION
## Summary

Supersedes conflicted PR #2 on the current main branch.

## Installed

- bounded, deduplicated remediation dispatch for stale StegDeploy publication receipts;
- federal-plus security baseline establishing applicable federal requirements as the minimum floor and requiring stronger, evidence-backed controls;
- durable session requirement transfer record.

## Boundaries

No compliance certification, provider execution, deployment, custody, publication, release, or activation authority is asserted. Downstream dispatch still requires a valid v2 PUBLISHED receipt with verified consumer pull.

## Validation

Repository checks must pass before merge. Runtime publication, remediation dispatch, and downstream compatibility remain evidence-gated.