### PR TITLE
Add bounded G18 pre-carrier Healer assist

### DIFF
--- a/.github/workflows/test-readiness.yml
+++ b/.github/workflows/test-readiness.yml
@@ -44,12 +44,6 @@ jobs:
               except Exception as exc:
                   failures.append(f'invalid JSON: {path}: {exc}')
 
-          tests = root / 'tests'
-          if tests.exists():
-              print(f'tests directory detected: {tests}')
-          else:
-              print('no tests directory detected; baseline smoke gate only')
-
           if failures:
               print('TEST READINESS FAILED')
               for failure in failures:
@@ -58,3 +52,12 @@ jobs:
 
           print('TEST READINESS PASSED')
           PY
+      - name: Run deterministic Healer tests
+        env:
+          GITHUB_TOKEN: ""
+          GH_TOKEN: ""
+          HEALER_GH_TOKEN: ""
+          HEALER_PAT: ""
+          GH_STEGVERSE_AI_TOKEN: ""
+        run: |
+          python -m unittest discover -s tests -p 'test_*.py' -v

--- a/app/pre_carrier_assist.py
+++ b/app/pre_carrier_assist.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+FORBIDDEN_CREDENTIALS = (
+    "HEALER_GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "HEALER_PAT",
+    "GH_STEGVERSE_AI_TOKEN",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "RENDER_API_KEY",
+    "VERCEL_TOKEN",
+    "CLOUDFLARE_API_TOKEN",
+    "WALLET_PRIVATE_KEY",
+    "PRIVATE_KEY",
+)
+
+REQUIRED_FILES = (
+    "control/heartbeat-state.json",
+    "heartbeat_runtime/engine_v12.py",
+    "heartbeat_runtime/worker_runtime.py",
+    "scripts/advance_heartbeat_transition.py",
+    "management/SHWP_STATE_TRANSITION_CONTINUITY_CONTRACT.json",
+    "handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json",
+    "control/worker-registry.json",
+    "control/process-worker-adapters.json",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _roots() -> dict[str, Path]:
+    raw = os.getenv("STEGVERSE_REPO_ROOTS_JSON", "").strip()
+    if not raw:
+        raise ValueError("STEGVERSE_REPO_ROOTS_JSON is required")
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("STEGVERSE_REPO_ROOTS_JSON must be an object")
+    roots: dict[str, Path] = {}
+    for repo, value in parsed.items():
+        if isinstance(repo, str) and isinstance(value, str):
+            root = Path(value).expanduser().resolve()
+            if root.is_dir():
+                roots[repo] = root
+    return roots
+
+
+def _forbid_credentials() -> list[str]:
+    return sorted(name for name in FORBIDDEN_CREDENTIALS if os.getenv(name))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def inspect_pre_carrier() -> dict[str, Any]:
+    forbidden = _forbid_credentials()
+    if forbidden:
+        return {
+            "schema": "stegverse.healer.pre_carrier_assist/v0.1",
+            "state": "FAILED",
+            "credential_authority": "TV/TVC",
+            "credential_requirement": "NONE",
+            "github_token_required": False,
+            "non_tv_tvc_secret_or_token_used": False,
+            "reason": "FORBIDDEN_CREDENTIAL_ENV_PRESENT",
+            "forbidden": forbidden,
+            "next_action": "remove forbidden credential material and retry the bounded local inspection",
+        }
+
+    roots = _roots()
+    root = roots.get("StegVerse-Labs/.github")
+    if root is None:
+        return {
+            "schema": "stegverse.healer.pre_carrier_assist/v0.1",
+            "state": "BLOCKED",
+            "credential_authority": "TV/TVC",
+            "credential_requirement": "NONE",
+            "github_token_required": False,
+            "non_tv_tvc_secret_or_token_used": False,
+            "reason": "CANONICAL_GITHUB_REPOSITORY_NOT_MATERIALIZED",
+            "next_action": "materialize the already-authorized StegVerse-Labs/.github source locally; do not use remote checkout as production transport",
+        }
+
+    missing = [rel for rel in REQUIRED_FILES if not (root / rel).is_file()]
+    if missing:
+        return {
+            "schema": "stegverse.healer.pre_carrier_assist/v0.1",
+            "state": "BLOCKED",
+            "credential_authority": "TV/TVC",
+            "credential_requirement": "NONE",
+            "github_token_required": False,
+            "non_tv_tvc_secret_or_token_used": False,
+            "reason": "REQUIRED_LOCAL_SOURCE_MISSING",
+            "missing": missing,
+            "next_action": "restore the canonical local source capsule through its existing StegVerse owner before G18 transition execution",
+        }
+
+    legacy_path = root / "control/heartbeat-state.json"
+    contract_path = root / "management/SHWP_STATE_TRANSITION_CONTINUITY_CONTRACT.json"
+    handoff_path = root / "handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json"
+    legacy = _load_json(legacy_path)
+    contract = _load_json(contract_path)
+    handoff = _load_json(handoff_path)
+
+    checks = {
+        "legacy_epoch_is_29": legacy.get("epoch") == 29,
+        "legacy_generation_is_29": legacy.get("generation") == 29,
+        "contract_legacy_epoch_is_29": contract.get("legacy_epoch") == 29,
+        "contract_legacy_source_immutable": contract.get("legacy_source_immutable") is True,
+        "contract_first_successor_is_30": contract.get("first_successor_epoch") == 30,
+        "contract_runtime_is_v12": contract.get("canonical_runtime") == "heartbeat_runtime.engine_v12.HeartbeatRuntime",
+        "contract_worker_is_separate": contract.get("worker_runtime") == "heartbeat_runtime.worker_runtime.WorkerCoordinator",
+        "contract_transition_producer_matches": contract.get("transition_producer") == "scripts/advance_heartbeat_transition.py",
+        "contract_no_extra_machine": contract.get("another_physical_machine_required") is False,
+        "contract_no_always_on_host": contract.get("always_on_external_host_required") is False,
+        "contract_tv_tvc_authority": (contract.get("credential_boundary") or {}).get("credential_authority") == "TV/TVC",
+        "contract_no_non_tv_tvc_secret": (contract.get("credential_boundary") or {}).get("non_tv_tvc_secret_or_token_allowed") is False,
+        "handoff_g18_owner": (handoff.get("task") or {}).get("claim_state") == "MACHINE_OWNED_BOUND_G18",
+        "handoff_fence_18": (handoff.get("task") or {}).get("fencing_token") == 18,
+        "handoff_live_activation_unclaimed": (handoff.get("completion") or {}).get("live_activation_claimed") is False,
+    }
+
+    failed = sorted(name for name, passed in checks.items() if not passed)
+    state = "READY_FOR_G18_TRANSITION" if not failed else "REVIEW_REQUIRED"
+    next_action = (
+        "G18 executes scripts/advance_heartbeat_transition.py under its existing admitted claim/fence; Healer does not execute or synthesize the carrier transition"
+        if state == "READY_FOR_G18_TRANSITION"
+        else "reconcile the listed canonical contract mismatch before G18 transition execution"
+    )
+
+    return {
+        "schema": "stegverse.healer.pre_carrier_assist/v0.1",
+        "state": state,
+        "credential_authority": "TV/TVC",
+        "credential_requirement": "NONE",
+        "github_token_required": False,
+        "non_tv_tvc_secret_or_token_used": False,
+        "authority_effect": "NONE",
+        "heartbeat_transition_executed": False,
+        "hb30_synthesized": False,
+        "legacy_state_sha256": _sha256(legacy_path),
+        "checks": checks,
+        "failed_checks": failed,
+        "next_action": next_action,
+    }
+
+
+def main() -> int:
+    try:
+        receipt = inspect_pre_carrier()
+    except Exception as exc:
+        receipt = {
+            "schema": "stegverse.healer.pre_carrier_assist/v0.1",
+            "state": "FAILED",
+            "credential_authority": "TV/TVC",
+            "credential_requirement": "NONE",
+            "github_token_required": False,
+            "non_tv_tvc_secret_or_token_used": False,
+            "authority_effect": "NONE",
+            "heartbeat_transition_executed": False,
+            "error": str(exc),
+        }
+    print(json.dumps(receipt, sort_keys=True))
+    return 0 if receipt.get("state") == "READY_FOR_G18_TRANSITION" else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/session_consolidation/g18-pre-carrier-assist.json
+++ b/data/session_consolidation/g18-pre-carrier-assist.json
@@ -1,0 +1,35 @@
+{
+  "schema": "stegverse.session-work-claim/v1",
+  "task_id": "HEALER-G18-PRE-CARRIER-ASSIST-001",
+  "originating_goal": "Assist the canonical sovereign heartbeat worker without creating a second heartbeat/scheduler and without using NON-TV/TVC secrets or tokens.",
+  "repository": "StegVerse-Labs/StegVerse-Healer",
+  "branch": "feat/g18-pre-carrier-healer-assist",
+  "issue": "StegVerse-Labs/StegVerse-Healer#4",
+  "claimant": "current-session-healer-pre-carrier-integration-lane",
+  "role": "CLAIMED_FOR_IMPLEMENTATION",
+  "claim_created_at": "2026-08-17T14:39:58Z",
+  "release_condition": "Source and deterministic tests merge, Test Readiness passes on the implementation head, the Healer mirror handoff and .github G18 continuation record the assist path, and no live HB30 or G18 claim/fence mutation is performed by this lane.",
+  "surfaces": [
+    "app/pre_carrier_assist.py",
+    "tests/test_pre_carrier_assist.py",
+    ".github/workflows/test-readiness.yml",
+    "docs/HEALER_MIRROR_HANDOFF.md",
+    "data/session_consolidation/g18-pre-carrier-assist.json"
+  ],
+  "collision_boundaries": [
+    "Do not mutate control/heartbeat-state.json or synthesize HB30.",
+    "Do not mutate control/heartbeat-carrier-runtime-state.json, worker runtime state, G18 claim/fence/lease, or worker registry authority.",
+    "Do not create a second heartbeat, scheduler, or transition owner.",
+    "Do not consume or forward GitHub, provider, wallet, or other NON-TV/TVC credentials/tokens.",
+    "Do not sign or broadcast wallet transactions."
+  ],
+  "expected_evidence": [
+    "pre-carrier assist returns READY_FOR_G18_TRANSITION only when immutable HB29 and the canonical v12/G18 contract are locally coherent",
+    "contract/source drift returns BLOCKED or REVIEW_REQUIRED with exact next action",
+    "credential-bearing environments fail closed",
+    "tests prove no HB30 synthesis and no legacy HB29 mutation"
+  ],
+  "canonical_runtime_owner": "StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json#G18",
+  "next_task_after_release": "G18 consumes the Healer pre-carrier receipt/diagnosis as bounded readiness evidence and remains the sole executor of scripts/advance_heartbeat_transition.py.",
+  "state": "CLAIMED_FOR_IMPLEMENTATION"
+}

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -4,47 +4,54 @@
 
 - Organization: `StegVerse-Labs`
 - Repository: `StegVerse-Labs/StegVerse-Healer`
-- Branch: `main`
-- Goal ID: `HEALER-TV-TVC-NO-GITHUB-TOKEN-DISPATCH-001`
-- Originating session goal: remove GitHub-token production/control-plane authority, preserve TV/TVC as credential/admission authority, and bind Healer scheduling/maintenance to the single resident sovereign heartbeat.
+- Branch: `main` after merge of `feat/g18-pre-carrier-healer-assist`
+- Primary goal ID: `HEALER-TV-TVC-NO-GITHUB-TOKEN-DISPATCH-001`
+- Active integration goal ID: `HEALER-G18-PRE-CARRIER-ASSIST-001`
+- Originating goal: keep Healer scheduling/repair local and sovereign, preserve TV/TVC as the only credential/admission authority, and assist canonical heartbeat recovery without creating a second heartbeat or scheduler.
 - Canonical organization continuation: `StegVerse-Labs/.github/docs/ORG_MIRROR_HANDOFF.md`
-- Canonical worker continuation: `StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json`
-- Repository-local continuation: this handoff plus `data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json` and `data/summary/single_scheduler_migration.json`.
-- Current repository state: `SOVEREIGN_SOURCE_COMPLETE_LIVE_CARRIER_MACHINE_OWNED`.
-- Chat-session role: `MERGED_INTO_CANONICAL_WORKSTREAM`.
+- Canonical heartbeat continuation: `StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json`
+- Canonical Healer scheduler continuation: `StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json`
+- Repository-local continuation: this handoff, `data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json`, `data/session_consolidation/g18-pre-carrier-assist.json`, and `data/summary/single_scheduler_migration.json`.
 
 ## Governing invariants
 
 ```text
 credential_authority: TV/TVC
+credential_requirement_for_pre_carrier_assist: NONE
+non_tv_tvc_secret_or_token_allowed: false
 github_token_production_authority: NONE
 github_actions_production_role: NONE
-production_clock: single resident StegVerse heartbeat
+heartbeat_owner: StegVerse-Labs/.github G18
+healer_pre_carrier_authority_effect: NONE
+healer_may_execute_hb29_to_hb30_transition: false
+healer_may_synthesize_hb30: false
 arbitrary_target_command_authority: NONE
 remote_source_checkout_required_for_production: false
 missing local capability: FAIL_CLOSED
 hosted validation: non-authorizing
 ```
 
-GitHub Actions may validate source when useful, but it is not a production scheduler, heartbeat carrier, credential authority, repository mutator, relay, deployment authority, or activation proof.
+Healer may inspect and diagnose the canonical heartbeat source before HB30 exists. It does not own the heartbeat transition, worker claim/fence/lease, carrier state, provider/wallet state, or TV/TVC authority.
 
 ## Authoritative files
 
 ```text
 docs/HEALER_MIRROR_HANDOFF.md
-data/orchestrator_targets.json
-data/summary/single_scheduler_migration.json
-data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json
-data/session_consolidation/stegdb-healer-canonical-import.json
 app/sovereign_scheduler.py
-app/dispatch_orchestrators.py
-app/audit_schedules.py
-app/relay_stegdeploy_publication.py
+app/pre_carrier_assist.py
+tests/test_pre_carrier_assist.py
+data/orchestrator_targets.json
+data/session_consolidation/g18-pre-carrier-assist.json
+data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json
+data/summary/single_scheduler_migration.json
+.github/workflows/test-readiness.yml
 ```
 
 Cross-repository authority/evidence:
 
 ```text
+StegVerse-Labs/.github/management/SHWP_STATE_TRANSITION_CONTINUITY_CONTRACT.json
+StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json
 StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json
 StegVerse-Labs/.github/authorizations/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json
 StegVerse-Labs/.github/control/worker-registry.d/healer-sovereign-scheduler-001.json
@@ -52,211 +59,170 @@ StegVerse-Labs/.github/control/process-worker-adapters.json
 StegVerse-Labs/TV/scripts/sovereign_self_heal.py
 StegVerse-Labs/TVC/policies/local_repository_mutation/tv_self_heal.v1.json
 StegVerse-Labs/SCW/scw/local_health.py
-StegVerse-Labs/SCW/scw/scw_core.py
 StegVerse-Labs/Continuity/scripts/guardian.py
-StegVerse-org/core-node-runtime-demo/tools/stegdeploy_runtime_intake_local.py
 ```
 
 ## Execution ownership and claims
 
 ### MACHINE_OWNED — do not compete
 
+`SHWP-DURABLE-RUNTIME-ACTIVATION / G18 / fencing token 18` owns the real HB29→HB30+ transition and subsequent independent WorkerCoordinator observation.
+
+`SHWP-HEALER-SOVEREIGN-SCHEDULER-001` owns ordinary post-carrier Healer scheduling and fixed local target execution.
+
+Neither machine path may be replaced by a chat session, GitHub Actions, Render, Vercel, Cloudflare, hosted inference, or another scheduler/process host.
+
+### Session implementation claim
+
 ```yaml
-- task_id: SHWP-HEALER-SOVEREIGN-SCHEDULER-001
-  execution_owner: resident sovereign heartbeat + healer-sovereign-scheduler-worker
-  claim_state: MACHINE_OWNED
-  worker_registry_ref: StegVerse-Labs/.github/control/worker-registry.d/healer-sovereign-scheduler-001.json
-  manual_execution_allowed: false
-  manual_allowed_role: observation
-  collision_scope: scheduler claim/fence, process-adapter invocation, live target execution, scheduler receipt persistence
-  release_condition: admitted heartbeat execution emits the no-token scheduler receipt and current target state
-  next_executable_action: resident heartbeat executes the worker under its current admitted claim/fence
+task_id: HEALER-G18-PRE-CARRIER-ASSIST-001
+issue: StegVerse-Labs/StegVerse-Healer#4
+claimant: current-session-healer-pre-carrier-integration-lane
+role: CLAIMED_FOR_IMPLEMENTATION
+claim_created_at: 2026-08-17T14:39:58Z
+files:
+  - app/pre_carrier_assist.py
+  - tests/test_pre_carrier_assist.py
+  - .github/workflows/test-readiness.yml
+  - data/session_consolidation/g18-pre-carrier-assist.json
+  - docs/HEALER_MIRROR_HANDOFF.md
+release_condition: merge validated source, record the G18 continuation, then mark COMPLETE_RELEASED
+collision_boundary: no live heartbeat/worker claim/fence/lease/carrier-state mutation and no credential/provider/wallet authority
 ```
 
-### COMPLETED / SUPERSEDED
+There is no separate validation claimant. Hosted Test Readiness is validation-only and non-authorizing.
 
-- GitHub API workflow-dispatch scheduler transport: `SUPERSEDED`.
-- `HEALER_GH_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, `HEALER_PAT`, `GH_STEGVERSE_AI_TOKEN` as production authority: `SUPERSEDED`.
-- duplicate `quiet-enforcer.yml` hosted scheduler: `SUPERSEDED`.
-- GitHub-hosted `supercheck_core.yml` mutation/PR transport: `SUPERSEDED`.
-- token-bearing `forward-to-bridge.yml` repository dispatch: `SUPERSEDED`.
-- broad scheduled `sync-to-canonical.yml` generic StegDB overwrite path: `SUPERSEDED`; durable record `data/session_consolidation/stegdb-healer-canonical-import.json`.
-- Healer source implementation for fixed local scheduling: `COMPLETE`.
-- heartbeat handoff/authorization/registry/process-adapter binding: `COMPLETE`.
+## Installed pre-carrier G18 assist
 
-No chat/session implementation claim remains on machine-owned runtime paths.
+`app/pre_carrier_assist.py` is a bounded local diagnostic/readiness producer for the already-materialized `StegVerse-Labs/.github` repository.
 
-## Installed sovereign scheduler
+It:
 
-`app/sovereign_scheduler.py`:
+- requires `STEGVERSE_REPO_ROOTS_JSON`; no remote checkout is a production fallback;
+- rejects GitHub/provider/wallet credential variables because this assist requires no credentials;
+- verifies immutable legacy HB29 and generation 29;
+- verifies the canonical v12 carrier and independent WorkerCoordinator source files;
+- verifies `management/SHWP_STATE_TRANSITION_CONTINUITY_CONTRACT.json` semantics, including first successor HB30, no extra-machine requirement, no always-on-host requirement, TV/TVC authority, and prohibition of NON-TV/TVC secret/token authority;
+- verifies G18 remains `MACHINE_OWNED_BOUND_G18` at fencing token 18 and live activation has not already been claimed;
+- emits `READY_FOR_G18_TRANSITION`, `BLOCKED`, `REVIEW_REQUIRED`, or `FAILED` plus an exact next action;
+- hashes legacy HB29 as evidence but does not mutate it;
+- does not invoke `scripts/advance_heartbeat_transition.py`;
+- does not create `control/heartbeat-carrier-runtime-state.json` and does not synthesize HB30.
 
-- rejects GitHub credential environment variables;
-- consumes `STEGVERSE_REPO_ROOTS_JSON` and only already-materialized repositories;
-- uses fixed code-defined handlers rather than commands supplied by target records;
-- evaluates cadence from `data/orchestrator_targets.json`;
-- returns `COMPLETE`, `BLOCKED`, `REVIEW_REQUIRED`, or `FAILED` according to actual handler outcomes;
-- treats missing repositories/capabilities as fail-closed conditions;
-- grants no GitHub, provider, wallet, release, deployment, or arbitrary process authority.
+This breaks the prior circular dependency at the diagnostic/repair-assist layer: Healer can now evaluate the prerequisites needed by G18 before the ordinary Healer scheduler itself is admitted by the heartbeat.
 
-The canonical heartbeat binding is `process:healer-sovereign-scheduler-v1`.
-
-## Managed target state
-
-### SCW
-
-Production execution is local through `scw.scw_core` and `scw/local_health.py`. Repository enumeration and required-file inspection use materialized roots rather than GitHub API credentials. Remote `autopatch` is not a fallback production mechanism. Hosted `scw_orchestrator.yml` and `uptime.yml` are compatibility/non-production surfaces.
-
-State: `SOVEREIGN_LOCAL_HANDLERS_BOUND`.
-
-### TV
-
-`StegVerse-Labs/TV/scripts/sovereign_self_heal.py` is the bounded local repair executor. It requires TVC-owned exact-scope policy from `StegVerse-Labs/TVC/policies/local_repository_mutation/tv_self_heal.v1.json`, uses the existing TVC execution-grant layer, limits repair classes to the admitted normalization boundary, and validates TV's operational handoff after mutation.
-
-State: `SOVEREIGN_LOCAL_HANDLER_BOUND_TVC_GRANT_REQUIRED`.
-
-### Continuity
-
-`StegVerse-Labs/Continuity/scripts/guardian.py` uses locally materialized repository roots and node-local acknowledgement evidence. GitHub issue enumeration, GitHub credentials, OIDC-for-GitHub execution, and hosted status pushing are not production dependencies. Hosted `continuity.yml` is a compatibility marker.
-
-State: `SOVEREIGN_LOCAL_GUARDIAN_BOUND`.
-
-### Site
-
-The Healer scheduler has a fixed local Site handler invoking the repository-owned local orchestration checks against a materialized Site tree. Site remains authoritative for its business logic and task admission.
-
-State: `SOVEREIGN_LOCAL_HANDLER_BOUND`.
-
-### Quiet Enforcer
-
-`app/audit_schedules.py` audits materialized workflow trees locally and fails closed when a required repository is absent. Hosted daily clocks and GitHub Contents API access are retired.
-
-State: `SOVEREIGN_LOCAL_HANDLER_BOUND`.
-
-### StegDeploy relay
-
-`app/relay_stegdeploy_publication.py` consumes locally materialized LLM-adapter/core-node state. Core-node local intake accepts the retained publication receipt only when the exact published digest is already present in the local Docker image store. It does not log into or pull from GHCR and does not use `repository_dispatch`.
-
-State: `SOVEREIGN_LOCAL_HANDLER_BOUND_LOCAL_IMAGE_PROOF_REQUIRED`.
-
-### CosDen / StegDB
-
-CosDen remains audit-only with canonical content ownership under `StegVerse-Labs/StegDB/canonical/cosden`.
-
-The previous broad Healer `sync-to-canonical.yml` behavior is intentionally not reproduced. StegDB contains multiple package-specific authorities and does not expose a single Healer-wide package that authorizes generic overwrite of workflows/policy/schema/docs/tools. A future import requires a new exact Healer-scoped manifest plus TVC mutation authority.
-
-Durable supersession record: `data/session_consolidation/stegdb-healer-canonical-import.json`.
-
-## Completed mutation evidence
-
-Key source/control commits include:
+The authority path is:
 
 ```text
-d972f0c92c7f492bcf420c96056f68ff4c47f65d  SCW local scanner
-06c14cbf9e9f9491532776bd241930e07083c725  SCW sovereign core
-b3df5feed791c18747f06e1d1a786cbc52d4c4ea  Healer sovereign scheduler
-0b07675ec2095ea3286f0fdff6553b7a55d9c37a  legacy dispatcher retirement
-2b2020538aa06a275229b94b0e25c1123297155d  heartbeat worker
-79f307d56127fb8490a78536c5be31452ee0b858  worker authorization
-84d173ba4dd61efc66504e46895e8218add35b43  process-adapter binding
-70cfd3f987783ad4c34c31b76509471c39663970  registry-fragment invariant correction
-95a596df289695b7dbb09807c59fa1812d0e1511  Continuity local guardian
-4bc4f7f89dc91712d337dbecab472584294d4b26  core-node local StegDeploy intake
-95860c2b0a366dd17e1b98cf5b5a987ad7c49974  TVC local mutation policy
-c0de3b8d057eb884aa9ed7cf09d301e761eef7a4  TV sovereign self-heal executor
-5cd027b05e31720ee3213dd5fcb860b897c7deda  TV hosted self-heal retirement
-f9bac0a7c0f05d9bb73a6d2783320854979a4bca  Continuity hosted production retirement
-9811fec37599cf0b5a3f1f38f863fa34f31dc9cd  SCW orchestrator hosted execution retirement
-6a0f081f356d24a7b5d88b945cb6d75188ea098c  SCW uptime hosted execution retirement
-3a36738524e1a045d584a3a7a4231b82563b32f1  supercheck mutation transport retirement
-2def997a49f77d707aa62ed5b97e333fd0a303b0  bridge token dispatch retirement
-67366a29437ed213aa763307acc596ccb52cf8b2  generic StegDB hosted sync retirement
-4ee44bbb996e2ca4a27ec7c072a68e6adb7911d9  target registry reconciliation
-e718664136579fb339940ee282f8e56fdc4a5225  StegDB sync supersession record
-a5a64d396ab811366fa0c978d6e6223beed67934  no-token migration ownership reconciliation
-c44029e8fb07e2659bd47334cd15f2ede2983699  sovereign scheduler migration receipt reconciliation
+materialized StegVerse source
+-> Healer pre-carrier inspection/diagnosis (authority_effect NONE)
+-> READY_FOR_G18_TRANSITION or exact fail-closed blocker
+-> existing G18 claim/fence
+-> scripts/advance_heartbeat_transition.py
+-> HB30+
+-> independent WorkerCoordinator observation
+-> ordinary Healer scheduler may later execute under its own admitted worker
 ```
 
-## Validation evidence
+## Existing sovereign scheduler
 
-Directly inspected Heartbeat Worker Project run `31624805596` executed an anonymous no-token source checkout, proved GitHub credential variables absent, compiled runtime/workers/scripts, and parsed canonical JSON. It then failed at `validate_executable_handoffs.py` because the earlier revision of `SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json` used an invalid `goal.successor_policy` value.
+`app/sovereign_scheduler.py` remains the ordinary Healer scheduler. It rejects GitHub credential variables, operates on already-materialized repositories, uses fixed code-defined handlers, fails closed on missing repositories/capabilities, and grants no GitHub/provider/wallet/release/deployment authority.
 
-The current handoff on `main` uses the admitted schema value `INHERIT_OR_NARROW` and includes the required `expires_at`. A successor hosted run has not been directly observed in this handoff and is therefore not claimed as passing.
+Managed local targets remain Site, SCW, SCW uptime, TV self-heal through TVC authority, Continuity, Quiet Enforcer, and StegDeploy relay. CosDen remains audit-only under StegDB canonical ownership.
 
-Hosted validation is not an activation gate. Live production activation requires resident-heartbeat execution evidence.
+## Completed source/control work
 
-## Machine-observable remaining activation work
+- GitHub workflow-dispatch as production scheduler transport: `SUPERSEDED`.
+- GitHub token/PAT production scheduler authority: `SUPERSEDED`.
+- SCW local scanner/runtime binding: `COMPLETE`.
+- Continuity local guardian binding: `COMPLETE`.
+- TV self-heal through TVC local mutation policy/grant: `COMPLETE` at source/control layer.
+- Quiet Enforcer local audit: `COMPLETE`.
+- StegDeploy local relay/intake: `COMPLETE` at source/control layer.
+- unsafe generic StegDB overwrite path: `SUPERSEDED`.
+- Healer scheduler worker authorization/registry/process-adapter binding: `COMPLETE`.
+- bounded G18 pre-carrier diagnostic source and deterministic tests: implemented on issue #4 branch; merge/validation evidence required before release claim.
 
-Owner: `StegVerse-Labs/.github` resident sovereign heartbeat.
+Earlier source/control history remains preserved in Git history and the migration records; this handoff is the canonical current continuation rather than a duplicate historical ledger.
+
+## Validation
+
+Required commands:
+
+```bash
+python -m unittest discover -s tests -p 'test_*.py' -v
+python app/pre_carrier_assist.py
+```
+
+For production-like pre-carrier inspection, `STEGVERSE_REPO_ROOTS_JSON` must map `StegVerse-Labs/.github` to an already-materialized local root. No credential is required.
+
+`.github/workflows/test-readiness.yml` performs JSON/smoke validation and deterministic unit tests. A passing hosted run proves source/test consistency only. It does not prove HB30, WorkerCoordinator runtime observation, scheduler activation, provider execution, wallet readiness, or trade execution.
+
+## Machine-observable incomplete work
+
+### Heartbeat activation
+
+Owner: `StegVerse-Labs/.github / SHWP-DURABLE-RUNTIME-ACTIVATION / G18`.
+
+Release condition:
 
 ```text
-SHWP-HEALER-SOVEREIGN-SCHEDULER-001
--> admitted claim/fence
--> process:healer-sovereign-scheduler-v1
--> materialized repository roots
--> fixed target handlers
--> no-token scheduler receipt
--> current target outcomes
+receipts/heartbeat-transition-continuity/latest.json = valid CARRIER_TRANSITION_COMPLETE at HB30+
+control/heartbeat-carrier-runtime-state.json = HB30+
+control/heartbeat-state.json = unchanged legacy HB29
+control/worker-runtime-state.json = independently observes carrier epoch
+worker-control-plane evidence present
+reconstruction PASS
+no duplicate claim/fence
+no NON-TV/TVC credential authority
 ```
 
-The organization-level carrier is itself still active machine work under `StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json`. This repository does not claim live scheduler execution until the carrier produces inspectable evidence.
+### Ordinary Healer scheduler activation
 
-No manual/session fallback is authorized for that runtime claim.
+Owner: `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`.
+
+Release condition: admitted post-carrier execution emits `receipts/healer-sovereign-scheduler/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json` with current target outcomes and no forbidden credential authority.
+
+### Downstream product activation
+
+Sovereign inference remains owned by `.github#60` and its TVC → LLM-adapter → Master Records chain. StegFin remains owned by its canonical worker/task state and must stop at `WALLET_HANDOFF_READY` before USER_ONLY signing/broadcast.
 
 ## Cross-repository propagation
 
-Activation evidence, when present and admitted by consumer release gates, may propagate to:
-
-```text
-StegVerse-Labs/Site
-GCAT-BCAT-Engine/Publisher
-StegVerse-Labs/admissibility-wiki
-StegVerse-Labs/stegguardian-wiki
-master-records/orchestration when required by the canonical activation chain
-```
-
-No propagation is claimed from source completion alone.
+No propagation is inferred from source completion. After immutable activation evidence and applicable consumer gates, evidence may propagate to Site, Publisher, admissibility-wiki, stegguardian-wiki, and passive Master Records custody where their canonical contracts require it.
 
 ## Session consolidation
 
-All session-specific Healer requirements are either completed, superseded, or durably transferred:
+Session-specific Healer requirements are durably represented by this handoff, issue #4, and `data/session_consolidation/g18-pre-carrier-assist.json`. Once issue #4 source is merged, Test Readiness is green, the claim record is `COMPLETE_RELEASED`, and the canonical G18 continuation references the assist path, no unique chat implementation responsibility remains for this Healer integration.
 
-1. remove GitHub-token production scheduler transport — complete;
-2. bind TV/TVC credential/admission authority — complete at source/control layer;
-3. bind scheduler to the resident heartbeat — complete at handoff/authorization/registry/process-adapter layer;
-4. migrate SCW — complete at source/control layer;
-5. migrate Continuity — complete at source/control layer;
-6. migrate TV self-heal to TVC execution grants — complete at source/control layer;
-7. migrate quiet-enforcer — complete at source/control layer;
-8. migrate StegDeploy relay/intake — complete at source/control layer;
-9. eliminate duplicate/bypass token-bearing workflows — complete/superseded;
-10. retire unsafe generic StegDB sync — complete/superseded with durable record;
-11. live resident execution — machine-owned by the canonical heartbeat, not a chat claim;
-12. downstream propagation — machine-owned successor condition after immutable activation evidence.
+MERGED INTO after release:
 
-MERGED INTO: `StegVerse-Labs/.github/docs/ORG_MIRROR_HANDOFF.md`, `StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json`, and this repository handoff.
-
-Deleting the chat does not remove an implementation requirement, credential decision, collision boundary, owner, release condition, or next executable action.
+```text
+StegVerse-Labs/StegVerse-Healer/docs/HEALER_MIRROR_HANDOFF.md
+StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json
+StegVerse-Labs/.github#65
+```
 
 ## Completion accounting
 
-Current goal denominator:
+Current denominator for this integration goal:
 
-- required developed/source-control deliverables: 24;
-- source/control validation groups: 6;
-- integration groups: 8;
-- live activation groups: 3;
-- session goals: 12.
+- required developed/source-control surfaces: 5;
+- deterministic validation groups: 2 (unit tests + Test Readiness workflow);
+- integration groups: 3 (Healer source/handoff, G18 durable continuation, claim release);
+- live activation groups: 2 (HB30+ carrier; independent WorkerCoordinator observation);
+- session transfer groups: 1.
 
-Current state:
+Current pre-merge state:
 
-- developed files/control surfaces: 24/24;
-- scaffolding or stubs: 0 production stubs;
-- missing required source/control files: 0;
-- validation: 5/6 — current successor hosted validation remains unobserved, while prior no-token checks reached the corrected handoff defect;
-- integration: 8/8 at source/control ownership level;
-- live activation: 1/3 — worker admission/binding installed; resident execution receipt and downstream propagation remain machine-owned;
-- session consolidation: 12/12.
+- developed files/control surfaces: 5/5;
+- scaffolding or production stubs: 0;
+- missing source/control files: 0;
+- deterministic validation: 1/2 pending hosted workflow evidence;
+- integration: 1/3 pending G18 continuation and claim release;
+- live activation: 0/2;
+- session consolidation: 0/1 until merge/claim release.
 
 ## Archive condition
 
-Repository/source work from this session is archive-safe. Product activation is not complete, but its remaining work is durably machine-owned by the canonical resident heartbeat and downstream consumer lanes. Archiving this session does not assert runtime activation.
+Do not treat this source implementation as HB30 activation. This Healer integration becomes archive-safe only after the branch is merged/validated, issue #4 and the claim record are released, and the canonical G18 continuation durably references the pre-carrier assist. Product activation may remain machine-owned after that transfer, but no chat-only requirement may remain.

--- a/tests/test_pre_carrier_assist.py
+++ b/tests/test_pre_carrier_assist.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "app" / "pre_carrier_assist.py"
+spec = importlib.util.spec_from_file_location("pre_carrier_assist", MODULE_PATH)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+class PreCarrierAssistTests(unittest.TestCase):
+    def _canonical_root(self, base: Path) -> Path:
+        root = base / ".github"
+        required = [
+            "heartbeat_runtime/engine_v12.py",
+            "heartbeat_runtime/worker_runtime.py",
+            "scripts/advance_heartbeat_transition.py",
+            "control/worker-registry.json",
+            "control/process-worker-adapters.json",
+        ]
+        for rel in required:
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{}\n", encoding="utf-8")
+
+        legacy = root / "control/heartbeat-state.json"
+        legacy.write_text(json.dumps({"epoch": 29, "generation": 29}) + "\n", encoding="utf-8")
+
+        contract = root / "management/SHWP_STATE_TRANSITION_CONTINUITY_CONTRACT.json"
+        contract.parent.mkdir(parents=True, exist_ok=True)
+        contract.write_text(json.dumps({
+            "legacy_epoch": 29,
+            "legacy_source_immutable": True,
+            "first_successor_epoch": 30,
+            "canonical_runtime": "heartbeat_runtime.engine_v12.HeartbeatRuntime",
+            "worker_runtime": "heartbeat_runtime.worker_runtime.WorkerCoordinator",
+            "transition_producer": "scripts/advance_heartbeat_transition.py",
+            "another_physical_machine_required": False,
+            "always_on_external_host_required": False,
+            "credential_boundary": {
+                "credential_authority": "TV/TVC",
+                "non_tv_tvc_secret_or_token_allowed": False,
+            },
+        }) + "\n", encoding="utf-8")
+
+        handoff = root / "handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json"
+        handoff.parent.mkdir(parents=True, exist_ok=True)
+        handoff.write_text(json.dumps({
+            "task": {"claim_state": "MACHINE_OWNED_BOUND_G18", "fencing_token": 18},
+            "completion": {"live_activation_claimed": False},
+        }) + "\n", encoding="utf-8")
+        return root
+
+    def test_ready_does_not_execute_transition_or_mutate_hb29(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = self._canonical_root(Path(td))
+            legacy = root / "control/heartbeat-state.json"
+            before = legacy.read_bytes()
+            env = {"STEGVERSE_REPO_ROOTS_JSON": json.dumps({"StegVerse-Labs/.github": str(root)})}
+            with patch.dict(os.environ, env, clear=True):
+                receipt = mod.inspect_pre_carrier()
+            self.assertEqual(receipt["state"], "READY_FOR_G18_TRANSITION")
+            self.assertFalse(receipt["heartbeat_transition_executed"])
+            self.assertFalse(receipt["hb30_synthesized"])
+            self.assertEqual(legacy.read_bytes(), before)
+            self.assertFalse((root / "control/heartbeat-carrier-runtime-state.json").exists())
+            self.assertEqual(receipt["credential_authority"], "TV/TVC")
+            self.assertFalse(receipt["github_token_required"])
+
+    def test_forbidden_github_token_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = self._canonical_root(Path(td))
+            env = {
+                "STEGVERSE_REPO_ROOTS_JSON": json.dumps({"StegVerse-Labs/.github": str(root)}),
+                "GITHUB_TOKEN": "forbidden",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                receipt = mod.inspect_pre_carrier()
+            self.assertEqual(receipt["state"], "FAILED")
+            self.assertIn("GITHUB_TOKEN", receipt["forbidden"])
+            self.assertFalse(receipt["non_tv_tvc_secret_or_token_used"])
+
+    def test_contract_drift_requires_review(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = self._canonical_root(Path(td))
+            contract_path = root / "management/SHWP_STATE_TRANSITION_CONTINUITY_CONTRACT.json"
+            contract = json.loads(contract_path.read_text(encoding="utf-8"))
+            contract["always_on_external_host_required"] = True
+            contract_path.write_text(json.dumps(contract) + "\n", encoding="utf-8")
+            env = {"STEGVERSE_REPO_ROOTS_JSON": json.dumps({"StegVerse-Labs/.github": str(root)})}
+            with patch.dict(os.environ, env, clear=True):
+                receipt = mod.inspect_pre_carrier()
+            self.assertEqual(receipt["state"], "REVIEW_REQUIRED")
+            self.assertIn("contract_no_always_on_host", receipt["failed_checks"])
+
+    def test_missing_local_source_blocks_without_remote_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / ".github"
+            root.mkdir()
+            env = {"STEGVERSE_REPO_ROOTS_JSON": json.dumps({"StegVerse-Labs/.github": str(root)})}
+            with patch.dict(os.environ, env, clear=True):
+                receipt = mod.inspect_pre_carrier()
+            self.assertEqual(receipt["state"], "BLOCKED")
+            self.assertEqual(receipt["reason"], "REQUIRED_LOCAL_SOURCE_MISSING")
+            self.assertFalse(receipt["github_token_required"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements issue #4 without creating a second heartbeat or scheduler.

Installed:
- `app/pre_carrier_assist.py` for credential-free local prerequisite inspection;
- deterministic tests proving immutable HB29, no HB30 synthesis, fail-closed credential handling, and contract-drift detection;
- Test Readiness now executes the Healer unit suite;
- canonical `docs/HEALER_MIRROR_HANDOFF.md` reconciled to the pre-carrier assist role;
- durable claim/transfer record in `data/session_consolidation/g18-pre-carrier-assist.json`.

Authority boundary: G18 remains sole HB29→HB30 transition owner. Healer does not invoke `advance_heartbeat_transition.py`, mutate heartbeat/worker claim state, consume/forward NON-TV/TVC secrets/tokens, contact provider/wallet surfaces, sign, or broadcast.

Hosted CI is validation-only and must not be represented as HB30 activation.