### PR TITLE
Bind Site Marketplace observer to sovereign local scheduler

### DIFF
--- a/.github/workflows/test-readiness.yml
+++ b/.github/workflows/test-readiness.yml
@@ -27,17 +27,19 @@ jobs:
       - name: Fetch exact Healer source anonymously
         shell: bash --noprofile --norc -e -o pipefail {0}
         env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          SOURCE_SHA="${PR_HEAD_SHA:-${GITHUB_SHA}}"
-          test -n "${SOURCE_SHA}"
-          curl --fail --silent --show-error --location \
-            "https://codeload.github.com/StegVerse-Labs/StegVerse-Healer/tar.gz/${SOURCE_SHA}" \
-            --output /tmp/healer-source.tar.gz
-          mkdir -p /tmp/healer-source
-          tar -xzf /tmp/healer-source.tar.gz --strip-components=1 -C /tmp/healer-source
-          cp -a /tmp/healer-source/. .
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            SOURCE_REF="refs/pull/${PR_NUMBER}/merge"
+          else
+            SOURCE_REF="${GITHUB_SHA}"
+          fi
+          git -c credential.helper= -c http.extraheader= fetch --no-tags --depth=50 origin "${SOURCE_REF}"
+          git checkout --detach FETCH_HEAD
+          test -z "$(git config --local --get-regexp 'extraheader|credential' || true)"
       - name: Verify preinstalled Python
         run: |
           python3 --version

--- a/.github/workflows/test-readiness.yml
+++ b/.github/workflows/test-readiness.yml
@@ -5,21 +5,50 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   repo-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - name: Refuse credential-bearing environment
+        shell: bash --noprofile --norc -e -o pipefail {0}
+        run: |
+          set -euo pipefail
+          for name in GITHUB_TOKEN GH_TOKEN GITHUB_PAT HEALER_GH_TOKEN HEALER_PAT GH_STEGVERSE_AI_TOKEN STEGVERSE_CROSS_REPO_READ_TOKEN MARKETPLACE_COINBASE_EVIDENCE_TOKEN ACTIONS_ID_TOKEN_REQUEST_TOKEN; do
+            if [ -n "${!name:-}" ]; then
+              echo "forbidden credential environment variable present: ${name}" >&2
+              exit 1
+            fi
+          done
+          echo 'HEALER_VALIDATION_CREDENTIAL_AUTHORITY=TV_TVC'
+          echo 'HEALER_VALIDATION_GITHUB_TOKEN_AUTHORITY=NONE'
+      - name: Fetch exact Healer source anonymously
+        shell: bash --noprofile --norc -e -o pipefail {0}
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          SOURCE_SHA="${PR_HEAD_SHA:-${GITHUB_SHA}}"
+          test -n "${SOURCE_SHA}"
+          curl --fail --silent --show-error --location \
+            "https://codeload.github.com/StegVerse-Labs/StegVerse-Healer/tar.gz/${SOURCE_SHA}" \
+            --output /tmp/healer-source.tar.gz
+          mkdir -p /tmp/healer-source
+          tar -xzf /tmp/healer-source.tar.gz --strip-components=1 -C /tmp/healer-source
+          cp -a /tmp/healer-source/. .
+      - name: Verify preinstalled Python
+        run: |
+          python3 --version
+          python3 - <<'PY'
+          import sys
+          assert sys.version_info >= (3, 11), sys.version
+          print('HEALER_VALIDATION_PYTHON=PASS')
+          PY
       - name: Baseline repository smoke test
         run: |
-          python - <<'PY'
+          python3 - <<'PY'
           from pathlib import Path
           import json
           import sys
@@ -53,11 +82,10 @@ jobs:
           print('TEST READINESS PASSED')
           PY
       - name: Run deterministic Healer tests
-        env:
-          GITHUB_TOKEN: ""
-          GH_TOKEN: ""
-          HEALER_GH_TOKEN: ""
-          HEALER_PAT: ""
-          GH_STEGVERSE_AI_TOKEN: ""
         run: |
-          python -m unittest discover -s tests -p 'test_*.py' -v
+          python3 -m unittest discover -s tests -p 'test_*.py' -v
+      - name: Confirm validation-only authority boundary
+        run: |
+          echo 'HEALER_VALIDATION_ONLY=TRUE'
+          echo 'HEALER_RUNTIME_EXECUTION_AUTHORITY=NONE'
+          echo 'HEALER_GITHUB_TOKEN_AUTHORITY=NONE'

--- a/app/sovereign_scheduler.py
+++ b/app/sovereign_scheduler.py
@@ -9,7 +9,15 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-FORBIDDEN_CREDENTIALS = ("HEALER_GH_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "HEALER_PAT", "GH_STEGVERSE_AI_TOKEN")
+FORBIDDEN_CREDENTIALS = (
+    "HEALER_GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "HEALER_PAT",
+    "GH_STEGVERSE_AI_TOKEN",
+    "MARKETPLACE_COINBASE_EVIDENCE_TOKEN",
+    "STEGVERSE_CROSS_REPO_READ_TOKEN",
+)
 
 
 def _forbid_github_credentials() -> None:
@@ -119,6 +127,23 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
             if result["returncode"] != 0:
                 return {**base, "state": "BLOCKED", "outcome": "SITE_LOCAL_ORCHESTRATION_BLOCKED", "execution": results}
         return {**base, "state": "COMPLETE", "outcome": "SOVEREIGN_LOCAL_SITE_ORCHESTRATION", "execution": results}
+
+    if repo == "StegVerse-Labs/Site" and workflow == "marketplace-coinbase-local-observer":
+        script = root / "scripts" / "advance_marketplace_coinbase_activation.py"
+        if not script.is_file():
+            return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_OBSERVER_MISSING"}
+        result = _run(
+            [sys.executable, str(script.relative_to(root))],
+            root,
+            {"STEGVERSE_REPO_ROOTS_JSON": all_roots_json},
+            timeout=90,
+        )
+        payload = _json_tail(result)
+        if result["returncode"] != 0 or not payload:
+            return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_OBSERVER_FAILED", "execution": result, "receipt": payload}
+        observed_state = str(payload.get("state", ""))
+        state = "COMPLETE" if observed_state in {"COMPLETE", "ACTIVE_STEGVERSE_CONTINUATION"} else "BLOCKED"
+        return {**base, "state": state, "outcome": "SOVEREIGN_LOCAL_SITE_MARKETPLACE_OBSERVATION", "execution": result, "receipt": payload}
 
     if repo == "StegVerse-Labs/TV" and workflow == "tv_self_heal.yml":
         tvc_root = roots.get("StegVerse-Labs/TVC")

--- a/data/orchestrator_targets.json
+++ b/data/orchestrator_targets.json
@@ -12,6 +12,16 @@
       "status": "sovereign-local-handler-bound"
     },
     {
+      "repo": "StegVerse-Labs/Site",
+      "workflow": "marketplace-coinbase-local-observer",
+      "ref": "main",
+      "enabled": true,
+      "aliases": ["site-marketplace-coinbase", "marketplace-coinbase-observer"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "inputs": {},
+      "status": "sovereign-local-hourly-observer-no-github-token-no-remote-checkout"
+    },
+    {
       "repo": "StegVerse-Labs/SCW",
       "workflow": "scw_orchestrator.yml",
       "ref": "main",

--- a/data/session_consolidation/site-marketplace-coinbase-local-observer.json
+++ b/data/session_consolidation/site-marketplace-coinbase-local-observer.json
@@ -1,0 +1,31 @@
+{
+  "schema": "stegverse.session-work-claim/v1",
+  "task_id": "HEALER-SITE-MARKETPLACE-COINBASE-LOCAL-OBSERVER-001",
+  "originating_goal": "Move the nonterminal Site#131 Marketplace-Coinbase observation loop from a GitHub-token/writeback controller to the existing sovereign Healer scheduler without creating a second scheduler or authority path.",
+  "repository": "StegVerse-Labs/StegVerse-Healer",
+  "branch": "feat/site-marketplace-coinbase-local-observer-6",
+  "issue": "StegVerse-Labs/StegVerse-Healer#6",
+  "site_issue": "StegVerse-Labs/Site#131",
+  "site_cleanup_pr": "StegVerse-Labs/Site#329",
+  "claimant": "current-session-healer-marketplace-observer-integration-lane",
+  "role": "CLAIMED_FOR_IMPLEMENTATION",
+  "claim_created_at": "2026-08-17T15:24:44Z",
+  "release_condition": "Fixed local handler, target registry, deterministic tests, and Healer mirror handoff merge; Test Readiness passes; Site PR #329 independently validates removal of the hosted token/writeback controller against the merged Healer continuation contract.",
+  "surfaces": [
+    "app/sovereign_scheduler.py",
+    "data/orchestrator_targets.json",
+    "tests/test_site_marketplace_coinbase_observer.py",
+    "docs/HEALER_MIRROR_HANDOFF.md",
+    "data/session_consolidation/site-marketplace-coinbase-local-observer.json"
+  ],
+  "collision_boundaries": [
+    "Reuse SHWP-HEALER-SOVEREIGN-SCHEDULER-001; do not create a second scheduler or heartbeat.",
+    "Operate only on already-materialized local repositories supplied by STEGVERSE_REPO_ROOTS_JSON.",
+    "Do not use GitHub API/token/PAT, remote checkout, provider, wallet, or other NON-TV/TVC credentials.",
+    "Do not grant Marketplace, Coinbase, Publisher, crypto-bot, Site publication/release/execution/live/financial authority.",
+    "Do not modify StegFin signing/broadcast authority; USER_ONLY remains sole signer/broadcaster.",
+    "Hosted validation is source evidence only and does not prove ordinary Healer scheduler activation."
+  ],
+  "canonical_scheduler_owner": "StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json",
+  "state": "CLAIMED_FOR_IMPLEMENTATION"
+}

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -160,6 +160,45 @@ python app/pre_carrier_assist.py
 
 Hosted runs are source/test evidence only. They do not prove HB30, independent WorkerCoordinator observation, ordinary Healer scheduler activation, provider execution, wallet readiness, signing, broadcast, or trade settlement.
 
+## Active Site Marketplace Coinbase local-observer integration
+
+Owner issue: `StegVerse-Labs/StegVerse-Healer#6`.
+
+Implementation PR: `StegVerse-Labs/StegVerse-Healer#7` on `feat/site-marketplace-coinbase-local-observer-6`.
+
+Claim record: `data/session_consolidation/site-marketplace-coinbase-local-observer.json`.
+
+Purpose: preserve the nonterminal Site#131 Marketplace–Coinbase observation semantics while retiring the GitHub-hosted Site controller/token/writeback path. The work reuses the existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`; it does not create another scheduler or heartbeat.
+
+Installed source behavior:
+
+- `data/orchestrator_targets.json` binds `StegVerse-Labs/Site` target `marketplace-coinbase-local-observer` to the existing sovereign scheduler;
+- `app/sovereign_scheduler.py` executes only the already-materialized Site `scripts/advance_marketplace_coinbase_activation.py` and passes local repository roots;
+- missing Site repository/script fails closed;
+- GitHub/Marketplace evidence token variables are forbidden;
+- no GitHub API, PAT, provider, wallet, Marketplace, Coinbase live/financial, publication, release or execution authority is granted;
+- Site PR #329 owns removal of `.github/workflows/advance-marketplace-coinbase-activation.yml` and conversion of the Site observer to local-repository evidence only.
+
+Validation evidence before this handoff update:
+
+```text
+PR #7 earlier source test: 32042403535 SUCCESS, 10 deterministic tests PASS
+credential audit of that run: actions/checkout and actions/setup-python still consumed GitHub-managed token transport
+credential-clean validation correction: ad98b4cf17ee70f6419be0f596937c525c523e5b
+credential-clean Test Readiness: 32044366801 SUCCESS
+job: 95429088491 SUCCESS
+credential refusal: PASS
+anonymous exact-ref fetch without credential helper/extraheader: PASS
+preinstalled Python: PASS
+baseline smoke: PASS
+deterministic Healer tests: PASS
+validation-only authority boundary: PASS
+```
+
+The `Test Readiness` workflow now has `permissions: {}`, no `actions/checkout`, no `actions/setup-python`, no artifact upload, no repository writeback, and no credential-bearing environment. Hosted validation remains non-authorizing.
+
+Release condition for this integration: exact-head validation after this handoff update must pass; PR #7 may then merge as source integration, while the claim remains active until companion Site PR #329 is independently validated/merged and continuation semantics are preserved. Ordinary Healer scheduler activation still requires the canonical admitted post-carrier worker receipt and is not inferred from CI or merge.
+
 ## Machine-observable incomplete work
 
 ### Heartbeat activation
@@ -199,7 +238,9 @@ No propagation is inferred from source completion. After immutable activation ev
 
 The unique Healer pre-carrier requirement is fully durable and transferred. The source is merged, tests are green, issue #4 is closed, claim state is `COMPLETE_RELEASED`, and `.github#65` contains the G18 consumption contract.
 
-MERGED INTO:
+The Site Marketplace Coinbase observer migration is active and durable in Healer issue #6, PR #7, the claim record, and Site PR #329. It remains a distinct support responsibility until Healer exact-head validation/merge and companion Site validation/merge complete.
+
+MERGED INTO for the released pre-carrier work:
 
 ```text
 StegVerse-Labs/StegVerse-Healer/docs/HEALER_MIRROR_HANDOFF.md
@@ -227,6 +268,8 @@ Current state:
 - live activation: 0/2 — intentionally machine-owned by G18 and independent WorkerCoordinator;
 - session consolidation for this Healer goal: 1/1.
 
+For `HEALER-SITE-MARKETPLACE-COINBASE-LOCAL-OBSERVER-001`, source/control surfaces are implemented; exact-head validation after the handoff update, merge, companion Site validation/merge, and claim release remain.
+
 ## Archive condition
 
-The Healer pre-carrier implementation itself is source/archive-safe and no longer chat-owned. The broader originating session is not product-activation complete while HB30+, independent WorkerCoordinator observation, sovereign inference, and StegFin `WALLET_HANDOFF_READY` remain unobserved. Do not interpret release of this Healer claim as completion of those machine-owned goals.
+The Healer pre-carrier implementation itself is source/archive-safe and no longer chat-owned. The broader originating session is not archive-ready while the active Site Marketplace Coinbase observer migration remains unmerged/unreleased and while Site workflow/token minimization continues. Live HB30+, independent WorkerCoordinator observation, sovereign inference and downstream product activation remain separately machine-owned and are not inferred from source/CI state.

--- a/tests/test_site_marketplace_coinbase_observer.py
+++ b/tests/test_site_marketplace_coinbase_observer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from app import sovereign_scheduler
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSiteMarketplaceCoinbaseObserver(unittest.TestCase):
+    def test_target_is_bound_to_existing_sovereign_scheduler(self):
+        config = json.loads((ROOT / "data" / "orchestrator_targets.json").read_text(encoding="utf-8"))
+        matches = [
+            target
+            for target in config["targets"]
+            if target.get("repo") == "StegVerse-Labs/Site"
+            and target.get("workflow") == "marketplace-coinbase-local-observer"
+        ]
+        self.assertEqual(len(matches), 1)
+        target = matches[0]
+        self.assertTrue(target["enabled"])
+        self.assertEqual(target["run_hours_utc"], list(range(24)))
+        self.assertIn("site-marketplace-coinbase", target["aliases"])
+
+    def test_marketplace_credentials_are_forbidden(self):
+        for name in ("MARKETPLACE_COINBASE_EVIDENCE_TOKEN", "STEGVERSE_CROSS_REPO_READ_TOKEN"):
+            with self.subTest(name=name), mock.patch.dict(os.environ, {name: "forbidden"}, clear=False):
+                with self.assertRaisesRegex(RuntimeError, "FORBIDDEN_GITHUB_CREDENTIAL_ENV"):
+                    sovereign_scheduler._forbid_github_credentials()
+
+    def test_handler_executes_only_materialized_site_script(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            scripts = site / "scripts"
+            scripts.mkdir(parents=True)
+            observer = scripts / "advance_marketplace_coinbase_activation.py"
+            observer.write_text(
+                "import json\nprint(json.dumps({'state':'ACTIVE_STEGVERSE_CONTINUATION','tasks':4}))\n",
+                encoding="utf-8",
+            )
+            roots = {"StegVerse-Labs/Site": site}
+            roots_json = json.dumps({key: str(value) for key, value in roots.items()})
+            target = {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-observer"}
+            result = sovereign_scheduler._execute_target(target, roots, roots_json)
+            self.assertEqual(result["state"], "COMPLETE")
+            self.assertEqual(result["outcome"], "SOVEREIGN_LOCAL_SITE_MARKETPLACE_OBSERVATION")
+            self.assertEqual(result["receipt"]["state"], "ACTIVE_STEGVERSE_CONTINUATION")
+            self.assertIn("STEGVERSE_REPO_ROOTS_JSON", roots_json and result["execution"]["command"] and "STEGVERSE_REPO_ROOTS_JSON")
+
+    def test_missing_site_observer_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            site.mkdir()
+            target = {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-observer"}
+            result = sovereign_scheduler._execute_target(target, {"StegVerse-Labs/Site": site}, json.dumps({"StegVerse-Labs/Site": str(site)}))
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_MARKETPLACE_OBSERVER_MISSING")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements Healer issue #6 using the existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`; no second scheduler or heartbeat is created.

Bounded delta:
- add a fixed local `StegVerse-Labs/Site` target `marketplace-coinbase-local-observer` to `data/orchestrator_targets.json`;
- bind that target in `app/sovereign_scheduler.py` to the already-materialized Site script `scripts/advance_marketplace_coinbase_activation.py`;
- pass only `STEGVERSE_REPO_ROOTS_JSON` so cross-repository observation resolves from local StegVerse materialization;
- explicitly reject `MARKETPLACE_COINBASE_EVIDENCE_TOKEN` and `STEGVERSE_CROSS_REPO_READ_TOKEN` in addition to existing GitHub credential variables;
- fail closed if the Site repository/script is not locally materialized;
- add deterministic tests and a durable active claim record.

Companion Site PR #329 now removes the hosted GitHub-token/writeback controller and is being tightened to local-repository observation only. This PR does not grant Marketplace, Coinbase live/financial, Publisher, crypto-bot, Site publication/release/execution, provider, HIL, StegOS, StegFin, credential, or wallet authority. TV/TVC remains credential authority and StegFin signing/broadcast remains USER_ONLY.

Hosted CI is source validation only; it does not prove ordinary Healer scheduler activation. Before merge: Test Readiness must pass, `docs/HEALER_MIRROR_HANDOFF.md` must record this fixed local target and exact evidence, and the claim must be released only after the corresponding Site controller-removal path is independently validated.