### PR TITLE
Bind Site Marketplace projection import to sovereign scheduler

### DIFF
--- a/app/sovereign_scheduler.py
+++ b/app/sovereign_scheduler.py
@@ -132,18 +132,28 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
         script = root / "scripts" / "advance_marketplace_coinbase_activation.py"
         if not script.is_file():
             return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_OBSERVER_MISSING"}
-        result = _run(
-            [sys.executable, str(script.relative_to(root))],
-            root,
-            {"STEGVERSE_REPO_ROOTS_JSON": all_roots_json},
-            timeout=90,
-        )
+        result = _run([sys.executable, str(script.relative_to(root))], root, {"STEGVERSE_REPO_ROOTS_JSON": all_roots_json}, timeout=90)
         payload = _json_tail(result)
         if result["returncode"] != 0 or not payload:
             return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_OBSERVER_FAILED", "execution": result, "receipt": payload}
         observed_state = str(payload.get("state", ""))
         state = "COMPLETE" if observed_state in {"COMPLETE", "ACTIVE_STEGVERSE_CONTINUATION"} else "BLOCKED"
         return {**base, "state": state, "outcome": "SOVEREIGN_LOCAL_SITE_MARKETPLACE_OBSERVATION", "execution": result, "receipt": payload}
+
+    if repo == "StegVerse-Labs/Site" and workflow == "marketplace-coinbase-local-projection-import":
+        script = root / "scripts" / "import_marketplace_coinbase_accessibility.py"
+        if not script.is_file():
+            return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_PROJECTION_IMPORTER_MISSING"}
+        if roots.get("GCAT-BCAT-Engine/Publisher") is None:
+            return {**base, "state": "BLOCKED", "outcome": "PUBLISHER_LOCAL_REPOSITORY_NOT_MATERIALIZED"}
+        result = _run([sys.executable, str(script.relative_to(root))], root, {"STEGVERSE_REPO_ROOTS_JSON": all_roots_json}, timeout=90)
+        status_path = root / "data" / "marketplace-coinbase-accessibility-status.json"
+        payload = json.loads(status_path.read_text(encoding="utf-8")) if status_path.is_file() else None
+        if result["returncode"] != 0 or not payload:
+            return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_PROJECTION_IMPORT_FAILED", "execution": result, "receipt": payload}
+        projected_state = str(payload.get("state", ""))
+        state = "COMPLETE" if projected_state in {"PAPER_ACCESSIBLE", "PENDING_UPSTREAM"} else "BLOCKED"
+        return {**base, "state": state, "outcome": "SOVEREIGN_LOCAL_SITE_MARKETPLACE_PROJECTION_IMPORT", "execution": result, "receipt": payload}
 
     if repo == "StegVerse-Labs/TV" and workflow == "tv_self_heal.yml":
         tvc_root = roots.get("StegVerse-Labs/TVC")

--- a/data/orchestrator_targets.json
+++ b/data/orchestrator_targets.json
@@ -22,6 +22,16 @@
       "status": "sovereign-local-hourly-observer-no-github-token-no-remote-checkout"
     },
     {
+      "repo": "StegVerse-Labs/Site",
+      "workflow": "marketplace-coinbase-local-projection-import",
+      "ref": "main",
+      "enabled": true,
+      "aliases": ["site-marketplace-projection", "marketplace-coinbase-projection"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "inputs": {},
+      "status": "sovereign-local-hourly-projection-import-no-github-token-no-remote-fetch"
+    },
+    {
       "repo": "StegVerse-Labs/SCW",
       "workflow": "scw_orchestrator.yml",
       "ref": "main",

--- a/data/session_consolidation/site-marketplace-projection-local-import.json
+++ b/data/session_consolidation/site-marketplace-projection-local-import.json
@@ -1,0 +1,31 @@
+{
+  "schema": "stegverse.session-work-claim/v1",
+  "task_id": "HEALER-SITE-MARKETPLACE-PROJECTION-LOCAL-IMPORT-001",
+  "originating_goal": "Move the Site#131 Marketplace-Coinbase projection importer from a scheduled GitHub-hosted writeback workflow to the existing sovereign Healer scheduler without introducing another scheduler or credential path.",
+  "repository": "StegVerse-Labs/StegVerse-Healer",
+  "branch": "feat/site-marketplace-projection-local-import-8",
+  "issue": "StegVerse-Labs/StegVerse-Healer#8",
+  "site_issue": "StegVerse-Labs/Site#131",
+  "site_coordination_issue": "StegVerse-Labs/Site#268",
+  "claimant": "current-session-healer-marketplace-projection-integration-lane",
+  "role": "CLAIMED_FOR_IMPLEMENTATION",
+  "claim_created_at": "2026-08-17T16:15:51Z",
+  "release_condition": "Fixed local Healer handler/target and deterministic tests merge with credential-clean validation; companion Site branch removes the hosted projection-import workflow, makes Publisher evidence local-only, passes exact-head Site validation, merges, and releases its claim.",
+  "surfaces": [
+    "app/sovereign_scheduler.py",
+    "data/orchestrator_targets.json",
+    "tests/test_site_marketplace_projection_import.py",
+    "docs/HEALER_MIRROR_HANDOFF.md",
+    "data/session_consolidation/site-marketplace-projection-local-import.json"
+  ],
+  "collision_boundaries": [
+    "Reuse SHWP-HEALER-SOVEREIGN-SCHEDULER-001; do not create a second scheduler or heartbeat.",
+    "Operate only on already-materialized Site and Publisher repositories supplied by STEGVERSE_REPO_ROOTS_JSON.",
+    "Do not use GitHub API/raw URL/token/PAT, provider, wallet, or other NON-TV/TVC credentials.",
+    "Do not grant Marketplace, Coinbase, Publisher, crypto-bot, Site publication/release/execution/live/financial authority.",
+    "Do not modify StegFin signing/broadcast authority; USER_ONLY remains sole signer/broadcaster.",
+    "Hosted validation is source evidence only and does not prove ordinary Healer scheduler activation."
+  ],
+  "canonical_scheduler_owner": "StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json",
+  "state": "CLAIMED_FOR_IMPLEMENTATION"
+}

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -7,12 +7,12 @@
 - Canonical branch: `main`
 - Primary goal ID: `HEALER-TV-TVC-NO-GITHUB-TOKEN-DISPATCH-001`
 - Released integration goals: `HEALER-G18-PRE-CARRIER-ASSIST-001`, `HEALER-SITE-MARKETPLACE-COINBASE-LOCAL-OBSERVER-001`
-- Originating goal: keep Healer scheduling/repair local and sovereign, preserve TV/TVC as the only credential/admission authority, assist canonical heartbeat recovery without creating a second heartbeat or scheduler, and absorb bounded recurring observation work from GitHub-hosted controllers when a fixed local handler is appropriate.
+- Active integration goal: `HEALER-SITE-MARKETPLACE-PROJECTION-LOCAL-IMPORT-001`
+- Originating goal: keep Healer scheduling/repair local and sovereign, preserve TV/TVC as the only credential/admission authority, assist canonical heartbeat recovery without creating a second heartbeat or scheduler, and absorb bounded recurring work from GitHub-hosted controllers only through fixed local handlers in the existing sovereign scheduler.
 - Canonical organization continuation: `StegVerse-Labs/.github/docs/ORG_MIRROR_HANDOFF.md`
 - Canonical heartbeat continuation: `StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json`
 - Canonical Healer scheduler continuation: `StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json`
-- Repository-local continuation: this handoff plus `data/session_consolidation/*.json` and `data/summary/single_scheduler_migration.json`.
-- Current repository state: `SOURCE_CONTROL_RELEASED_LIVE_SCHEDULER_ACTIVATION_MACHINE_OWNED`.
+- Current repository state: `SOURCE_CONTROL_ACTIVE_INTEGRATION_LIVE_SCHEDULER_ACTIVATION_MACHINE_OWNED`.
 
 ## Governing invariants
 
@@ -43,145 +43,135 @@ app/pre_carrier_assist.py
 data/orchestrator_targets.json
 tests/test_pre_carrier_assist.py
 tests/test_site_marketplace_coinbase_observer.py
+tests/test_site_marketplace_projection_import.py
 data/session_consolidation/g18-pre-carrier-assist.json
 data/session_consolidation/site-marketplace-coinbase-local-observer.json
+data/session_consolidation/site-marketplace-projection-local-import.json
 data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json
-data/summary/single_scheduler_migration.json
 .github/workflows/test-readiness.yml
 ```
 
-## Execution ownership and collision boundaries
+## Machine-owned execution boundaries
 
-### MACHINE_OWNED — do not compete
-
-`SHWP-DURABLE-RUNTIME-ACTIVATION / G18` owns the real HB29→HB30+ transition and handoff to independently admitted WorkerCoordinator observation.
+`SHWP-DURABLE-RUNTIME-ACTIVATION / G18` owns HB29→HB30+ and the independent WorkerCoordinator observation handoff.
 
 `SHWP-HEALER-SOVEREIGN-SCHEDULER-001` owns ordinary post-carrier Healer scheduling and fixed local target execution.
 
-Neither machine path may be replaced by a chat session, GitHub Actions, Render, Vercel, Cloudflare, hosted inference, or another scheduler/process host.
+Neither machine path may be replaced by a chat session, GitHub Actions, Render, hosted inference, or another scheduler/process host.
 
 ## Released G18 pre-carrier assist
 
-Claim record: `data/session_consolidation/g18-pre-carrier-assist.json`.
-
 ```text
-issue: StegVerse-Healer#4 CLOSED_COMPLETED
-PR: StegVerse-Healer#5 MERGED
+claim: HEALER-G18-PRE-CARRIER-ASSIST-001 / COMPLETE_RELEASED
+issue: #4 CLOSED_COMPLETED
+PR: #5 MERGED
 merge: 571b6a86737173a89235110294025f9808695531
 PR-head Test Readiness: 32039990314 SUCCESS
 main Test Readiness: 32040015153 SUCCESS
 main Validate Session Consolidation: 32040015173 SUCCESS
-claim_state: COMPLETE_RELEASED
 authority_effect: NONE
 ```
 
-`app/pre_carrier_assist.py` inspects an already-materialized `.github` source tree, verifies immutable HB29 / v12 / G18 prerequisites, refuses forbidden credential environments, and returns `READY_FOR_G18_TRANSITION`, `BLOCKED`, `REVIEW_REQUIRED`, or `FAILED`. It does not invoke the transition producer, synthesize HB30, or mutate legacy HB29.
+The assist verifies immutable HB29/v12/G18 prerequisites from already-materialized source and does not synthesize HB30 or invoke the transition producer.
 
-## Released Site Marketplace–Coinbase local observer integration
-
-Claim record: `data/session_consolidation/site-marketplace-coinbase-local-observer.json`.
-
-Purpose: replace the GitHub-hosted Site Marketplace/Coinbase observation controller with a fixed local target in the existing sovereign Healer scheduler while preserving the nonterminal product chain and all authority boundaries.
-
-Installed behavior:
-
-- `data/orchestrator_targets.json` binds Site target `marketplace-coinbase-local-observer` to the existing scheduler;
-- `app/sovereign_scheduler.py` invokes only the already-materialized Site `scripts/advance_marketplace_coinbase_activation.py`;
-- `STEGVERSE_REPO_ROOTS_JSON` is the only repository-materialization input;
-- missing local Site script/repository fails closed;
-- GitHub and Marketplace evidence credential variables are rejected;
-- no GitHub API/PAT/provider/wallet credential path is present;
-- no second scheduler or heartbeat was created;
-- no Marketplace, Coinbase live/financial, Publisher, crypto-bot, Site publication/release/execution, StegFin, or wallet authority was granted.
-
-Release evidence:
+## Released Site Marketplace observer integration
 
 ```text
-Healer issue: #6
-Healer PR: #7
-Healer final head: 547d44555be78e610fd4623ca30786fc02188221
+claim: HEALER-SITE-MARKETPLACE-COINBASE-LOCAL-OBSERVER-001 / COMPLETE_RELEASED
+issue: #6 CLOSED_COMPLETED
+PR: #7 MERGED
 Healer merge: ecf96188348c097dfdea3ce55c47db9dff6e84ef
-Healer credential-clean Test Readiness: 32044423476 SUCCESS
-Healer validation job: 95429249175 SUCCESS
-Site PR: #329
-Site final head: caf9b6dae32f09b7475a0dbe61cbc5e7e873c089
-Site merge: 72ca1b9377a918983d5bcb329fa4c13ab0294cc8
-Site Bootstrap Validate: 32044523223 SUCCESS
-Site Handoff Orchestrator: 32044523168 SUCCESS
-Ecosystem Heartbeat Orchestration: 32044523264 SUCCESS
-Check StegFin Phone Projection: 32044523162 SUCCESS
+Healer Test Readiness: 32044423476 SUCCESS
+Site PR #329 merge: 72ca1b9377a918983d5bcb329fa4c13ab0294cc8
 Site claim release: c00ac1906dc6bcfd5195e07dc7916e3cc2d760bc
-Site Actions handoff release: c0c87e2004e41acb22afe7fddaec61947d451df4
-Site Marketplace handoff release: 60b7cd74be751df8b11e7b5bbc940dc4fd0319a9
 Healer claim release: 76b5523e02dbc37ad726ece7689902d551604a75
-claim_state: COMPLETE_RELEASED
 authority_effect: NONE
 runtime_activation_effect: NONE
 financial_authority_effect: NONE
 ```
 
-The credential-clean Healer `Test Readiness` path uses `permissions: {}`, refuses credential-bearing environment, anonymously fetches the exact public ref with credential helper/extraheader disabled, uses preinstalled Python, performs no repository writeback or artifact upload, and grants no runtime authority.
+Fixed target `marketplace-coinbase-local-observer` invokes only the already-materialized Site observation script and uses local repository roots. No GitHub API/token/PAT path or second scheduler exists.
+
+## Active Site Marketplace projection-import integration
+
+Claim: `HEALER-SITE-MARKETPLACE-PROJECTION-LOCAL-IMPORT-001`.
+
+Issue: `StegVerse-Labs/StegVerse-Healer#8`.
+
+PR: `StegVerse-Labs/StegVerse-Healer#9` on `feat/site-marketplace-projection-local-import-8`.
+
+Purpose: remove the remaining scheduled GitHub-hosted Site Marketplace/Coinbase projection importer and execute that bounded recurrence through the existing sovereign Healer scheduler.
+
+Installed behavior:
+
+- `data/orchestrator_targets.json` binds fixed target `marketplace-coinbase-local-projection-import` to the existing scheduler;
+- `app/sovereign_scheduler.py` invokes only the already-materialized Site `scripts/import_marketplace_coinbase_accessibility.py`;
+- both Site and `GCAT-BCAT-Engine/Publisher` must be present in `STEGVERSE_REPO_ROOTS_JSON`;
+- missing Site importer or Publisher repository fails closed;
+- no GitHub API, raw GitHub URL, PAT, provider, wallet, or NON-TV/TVC credential is used;
+- no second scheduler or heartbeat is created;
+- no publication, release, execution, live, custody, withdrawal, or financial authority is granted.
+
+Deterministic tests added in `tests/test_site_marketplace_projection_import.py` verify fixed-target binding, missing-Site failure, missing-Publisher failure, and local execution against materialized Site/Publisher repositories.
+
+Validation before this handoff update:
+
+```text
+PR #9 Test Readiness: 32045128811 SUCCESS
+job: 95431214621 SUCCESS
+credential refusal: PASS
+anonymous exact-ref validation fetch: PASS
+baseline smoke: PASS
+14 deterministic Healer tests: PASS
+validation-only authority boundary: PASS
+```
+
+Companion Site branch `chore/site-marketplace-projection-import-retirement-20260817` removes `.github/workflows/import-marketplace-coinbase-accessibility.yml`, makes the Site importer local-only, expands deterministic tests, and carries semantic claim `SITE-MARKETPLACE-COINBASE-PROJECTION-IMPORT-RETIREMENT-20260817`.
+
+Release condition: exact-head credential-clean Healer validation after this handoff update must pass; PR #9 may then merge as source integration. The Healer claim remains active until companion Site exact-head validation/merge and Site claim/handoff release complete. Ordinary Healer runtime activation remains a separate machine-owned gate.
+
+## Credential-clean hosted validation boundary
+
+`.github/workflows/test-readiness.yml` uses `permissions: {}`, refuses credential-bearing environment, performs an anonymous exact-ref fetch with credential helper/extraheader disabled, uses preinstalled Python, performs no repository writeback or artifact upload, and emits:
+
+```text
+HEALER_VALIDATION_ONLY=TRUE
+HEALER_RUNTIME_EXECUTION_AUTHORITY=NONE
+HEALER_GITHUB_TOKEN_AUTHORITY=NONE
+```
+
+GitHub runner metadata may expose platform-level metadata permission, but the workflow does not consume a GitHub token as an input or authority surface.
 
 ## Ordinary scheduler activation remains unproven
 
-Source merge and CI success do not prove live Healer execution. Runtime activation remains owned by `SHWP-HEALER-SOVEREIGN-SCHEDULER-001` and requires an admitted post-carrier execution receipt:
+Source merge/CI do not prove live Healer execution. Activation requires admitted post-carrier execution receipt:
 
 ```text
 receipts/healer-sovereign-scheduler/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json
 ```
 
-The receipt must show current fixed-target outcomes and no forbidden credential authority.
+## Downstream owners
 
-## Heartbeat activation remains machine-owned
-
-Owner: `StegVerse-Labs/.github / SHWP-DURABLE-RUNTIME-ACTIVATION / G18`.
-
-Release condition remains:
-
-```text
-receipts/heartbeat-transition-continuity/latest.json = valid CARRIER_TRANSITION_COMPLETE at HB30+
-control/heartbeat-carrier-runtime-state.json = HB30+
-control/heartbeat-state.json = unchanged legacy HB29
-control/worker-runtime-state.json = independently observes carrier epoch
-worker-control-plane evidence present
-reconstruction PASS
-no duplicate claim/fence
-no NON-TV/TVC credential authority
-```
-
-## Downstream activation
-
-- Sovereign inference remains owned by `.github#60` and its TVC → LLM-adapter → Master Records chain.
-- StegFin remains owned by its canonical task state and current phone path; USER_ONLY remains the sole signer/broadcaster.
-- Site workflow/token minimization continues under `StegVerse-Labs/Site#268`.
-
-## Session consolidation
-
-The Healer-specific Marketplace observer work from this session is fully durable, source-merged, validated, and released. No chat-owned Healer implementation claim remains.
-
-MERGED INTO:
-
-```text
-StegVerse-Labs/StegVerse-Healer/docs/HEALER_MIRROR_HANDOFF.md
-StegVerse-Labs/StegVerse-Healer/data/session_consolidation/site-marketplace-coinbase-local-observer.json
-StegVerse-Labs/Site/docs/ACTIONS_COST_CONTAINMENT_MIRROR_HANDOFF.md
-StegVerse-Labs/Site#268
-```
+- HB30+ / WorkerCoordinator: `.github` G18 machine owner.
+- Sovereign inference: `.github#60` TVC → LLM-adapter → Master Records chain.
+- StegFin: canonical worker/task state and phone path; USER_ONLY signing/broadcast.
+- Site workflow/token minimization: `StegVerse-Labs/Site#268`.
 
 ## Completion accounting
 
-For `HEALER-SITE-MARKETPLACE-COINBASE-LOCAL-OBSERVER-001`:
+Released Healer source goals are complete. For active `HEALER-SITE-MARKETPLACE-PROJECTION-LOCAL-IMPORT-001`:
 
 ```text
 developed/source-control surfaces: 5/5
 scaffolding or production stubs: 0
 missing source/control files: 0
-deterministic validation: 2/2
-cross-repository integration: 2/2 (Healer merge + Site controller retirement merge)
-claim release: 1/1
+pre-handoff deterministic validation: PASS
+exact-head post-handoff validation: PENDING
+Healer source merge: PENDING
+companion Site integration: PENDING
 live scheduler activation: separate MACHINE_OWNED gate; not inferred
 ```
 
 ## Archive condition
 
-The Healer-specific support task is archive-safe. The broader originating session is not archive-ready because Site #268 still has executable workflow/token minimization debt. HB30+, independent WorkerCoordinator observation, sovereign inference, ordinary Healer execution, and downstream product activation remain separately machine-owned and are not inferred from source/CI state.
+The broader session is not archive-ready while this active Healer/Site projection-import migration remains unreleased and Site #268 retains additional workflow/token minimization debt. Machine-owned runtime/product activation remains separate and is not inferred from source or CI state.

--- a/tests/test_site_marketplace_projection_import.py
+++ b/tests/test_site_marketplace_projection_import.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app import sovereign_scheduler
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSiteMarketplaceProjectionImport(unittest.TestCase):
+    def test_target_is_bound_to_existing_scheduler(self):
+        config = json.loads((ROOT / "data" / "orchestrator_targets.json").read_text(encoding="utf-8"))
+        matches = [
+            target for target in config["targets"]
+            if target.get("repo") == "StegVerse-Labs/Site"
+            and target.get("workflow") == "marketplace-coinbase-local-projection-import"
+        ]
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["run_hours_utc"], list(range(24)))
+        self.assertIn("marketplace-coinbase-projection", matches[0]["aliases"])
+
+    def test_missing_site_importer_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            publisher = Path(temp_dir) / "Publisher"
+            site.mkdir()
+            publisher.mkdir()
+            roots = {
+                "StegVerse-Labs/Site": site,
+                "GCAT-BCAT-Engine/Publisher": publisher,
+            }
+            roots_json = json.dumps({key: str(value) for key, value in roots.items()})
+            result = sovereign_scheduler._execute_target(
+                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"},
+                roots,
+                roots_json,
+            )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_MARKETPLACE_PROJECTION_IMPORTER_MISSING")
+
+    def test_missing_publisher_repo_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            scripts = site / "scripts"
+            scripts.mkdir(parents=True)
+            (scripts / "import_marketplace_coinbase_accessibility.py").write_text("raise SystemExit(0)\n", encoding="utf-8")
+            roots = {"StegVerse-Labs/Site": site}
+            roots_json = json.dumps({key: str(value) for key, value in roots.items()})
+            result = sovereign_scheduler._execute_target(
+                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"},
+                roots,
+                roots_json,
+            )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "PUBLISHER_LOCAL_REPOSITORY_NOT_MATERIALIZED")
+
+    def test_handler_executes_local_site_importer_with_local_publisher(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            publisher = Path(temp_dir) / "Publisher"
+            scripts = site / "scripts"
+            data = site / "data"
+            scripts.mkdir(parents=True)
+            data.mkdir(parents=True)
+            publisher.mkdir()
+            importer = scripts / "import_marketplace_coinbase_accessibility.py"
+            importer.write_text(
+                "import json\n"
+                "from pathlib import Path\n"
+                "Path('data/marketplace-coinbase-accessibility-status.json').write_text(json.dumps({'state':'PAPER_ACCESSIBLE'}))\n",
+                encoding="utf-8",
+            )
+            roots = {
+                "StegVerse-Labs/Site": site,
+                "GCAT-BCAT-Engine/Publisher": publisher,
+            }
+            roots_json = json.dumps({key: str(value) for key, value in roots.items()})
+            result = sovereign_scheduler._execute_target(
+                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"},
+                roots,
+                roots_json,
+            )
+            self.assertEqual(result["state"], "COMPLETE")
+            self.assertEqual(result["outcome"], "SOVEREIGN_LOCAL_SITE_MARKETPLACE_PROJECTION_IMPORT")
+            self.assertEqual(result["receipt"]["state"], "PAPER_ACCESSIBLE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements Healer issue #8 using the existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`.

Bounded delta:
- add fixed Site target `marketplace-coinbase-local-projection-import`;
- execute only the already-materialized Site `scripts/import_marketplace_coinbase_accessibility.py`;
- require already-materialized `GCAT-BCAT-Engine/Publisher` in `STEGVERSE_REPO_ROOTS_JSON`;
- fail closed when Site importer or Publisher local repository is missing;
- add deterministic tests and durable claim record;
- no GitHub API/raw URL/token/PAT/provider/wallet dependency;
- no second scheduler/heartbeat, no Render, no financial/live/publication authority.

Companion Site branch `chore/site-marketplace-projection-import-retirement-20260817` removes the scheduled GitHub-hosted projection workflow and makes Publisher evidence local-only. TV/TVC remains credential authority; USER_ONLY remains sole StegFin signer/broadcaster. Hosted validation is source evidence only and does not prove ordinary Healer runtime activation.