### PR TITLE
Fail closed until Site projection importer is sovereign-local

### DIFF
--- a/app/sovereign_scheduler.py
+++ b/app/sovereign_scheduler.py
@@ -92,6 +92,16 @@ def _json_tail(result: dict[str, Any]) -> dict[str, Any] | None:
         return None
 
 
+def _site_projection_importer_is_local_only(script: Path) -> bool:
+    try:
+        source = script.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    required = ("STEGVERSE_REPO_ROOTS_JSON", "GCAT-BCAT-Engine/Publisher")
+    forbidden = ("raw.githubusercontent.com", "urllib", "request.urlopen", "http://", "https://")
+    return all(marker in source for marker in required) and not any(marker in source for marker in forbidden)
+
+
 def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_json: str) -> dict[str, Any]:
     repo = str(target.get("repo", ""))
     workflow = str(target.get("workflow", ""))
@@ -144,6 +154,8 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
         script = root / "scripts" / "import_marketplace_coinbase_accessibility.py"
         if not script.is_file():
             return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_PROJECTION_IMPORTER_MISSING"}
+        if not _site_projection_importer_is_local_only(script):
+            return {**base, "state": "BLOCKED", "outcome": "SITE_MARKETPLACE_PROJECTION_LOCAL_CAPABILITY_NOT_INSTALLED"}
         if roots.get("GCAT-BCAT-Engine/Publisher") is None:
             return {**base, "state": "BLOCKED", "outcome": "PUBLISHER_LOCAL_REPOSITORY_NOT_MATERIALIZED"}
         result = _run([sys.executable, str(script.relative_to(root))], root, {"STEGVERSE_REPO_ROOTS_JSON": all_roots_json}, timeout=90)

--- a/tests/test_site_marketplace_projection_import.py
+++ b/tests/test_site_marketplace_projection_import.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from app import sovereign_scheduler
 
 ROOT = Path(__file__).resolve().parents[1]
+LOCAL_CAPABILITY_MARKERS = "# STEGVERSE_REPO_ROOTS_JSON\n# GCAT-BCAT-Engine/Publisher\n"
 
 
 class TestSiteMarketplaceProjectionImport(unittest.TestCase):
@@ -28,31 +29,45 @@ class TestSiteMarketplaceProjectionImport(unittest.TestCase):
             publisher = Path(temp_dir) / "Publisher"
             site.mkdir()
             publisher.mkdir()
-            roots = {
-                "StegVerse-Labs/Site": site,
-                "GCAT-BCAT-Engine/Publisher": publisher,
-            }
+            roots = {"StegVerse-Labs/Site": site, "GCAT-BCAT-Engine/Publisher": publisher}
             roots_json = json.dumps({key: str(value) for key, value in roots.items()})
             result = sovereign_scheduler._execute_target(
-                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"},
-                roots,
-                roots_json,
+                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"}, roots, roots_json
             )
             self.assertEqual(result["state"], "BLOCKED")
             self.assertEqual(result["outcome"], "SITE_MARKETPLACE_PROJECTION_IMPORTER_MISSING")
 
-    def test_missing_publisher_repo_fails_closed(self):
+    def test_legacy_remote_site_importer_fails_closed_before_execution(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            publisher = Path(temp_dir) / "Publisher"
+            scripts = site / "scripts"
+            scripts.mkdir(parents=True)
+            publisher.mkdir()
+            (scripts / "import_marketplace_coinbase_accessibility.py").write_text(
+                "from urllib import request\nSOURCE='https://raw.githubusercontent.com/example/repo/main/state.json'\n",
+                encoding="utf-8",
+            )
+            roots = {"StegVerse-Labs/Site": site, "GCAT-BCAT-Engine/Publisher": publisher}
+            roots_json = json.dumps({key: str(value) for key, value in roots.items()})
+            result = sovereign_scheduler._execute_target(
+                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"}, roots, roots_json
+            )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_MARKETPLACE_PROJECTION_LOCAL_CAPABILITY_NOT_INSTALLED")
+
+    def test_missing_publisher_repo_fails_closed_after_capability_check(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             site = Path(temp_dir) / "Site"
             scripts = site / "scripts"
             scripts.mkdir(parents=True)
-            (scripts / "import_marketplace_coinbase_accessibility.py").write_text("raise SystemExit(0)\n", encoding="utf-8")
+            (scripts / "import_marketplace_coinbase_accessibility.py").write_text(
+                LOCAL_CAPABILITY_MARKERS + "raise SystemExit(0)\n", encoding="utf-8"
+            )
             roots = {"StegVerse-Labs/Site": site}
             roots_json = json.dumps({key: str(value) for key, value in roots.items()})
             result = sovereign_scheduler._execute_target(
-                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"},
-                roots,
-                roots_json,
+                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"}, roots, roots_json
             )
             self.assertEqual(result["state"], "BLOCKED")
             self.assertEqual(result["outcome"], "PUBLISHER_LOCAL_REPOSITORY_NOT_MATERIALIZED")
@@ -68,20 +83,16 @@ class TestSiteMarketplaceProjectionImport(unittest.TestCase):
             publisher.mkdir()
             importer = scripts / "import_marketplace_coinbase_accessibility.py"
             importer.write_text(
-                "import json\n"
-                "from pathlib import Path\n"
-                "Path('data/marketplace-coinbase-accessibility-status.json').write_text(json.dumps({'state':'PAPER_ACCESSIBLE'}))\n",
+                LOCAL_CAPABILITY_MARKERS
+                + "import json\n"
+                + "from pathlib import Path\n"
+                + "Path('data/marketplace-coinbase-accessibility-status.json').write_text(json.dumps({'state':'PAPER_ACCESSIBLE'}))\n",
                 encoding="utf-8",
             )
-            roots = {
-                "StegVerse-Labs/Site": site,
-                "GCAT-BCAT-Engine/Publisher": publisher,
-            }
+            roots = {"StegVerse-Labs/Site": site, "GCAT-BCAT-Engine/Publisher": publisher}
             roots_json = json.dumps({key: str(value) for key, value in roots.items()})
             result = sovereign_scheduler._execute_target(
-                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"},
-                roots,
-                roots_json,
+                {"repo": "StegVerse-Labs/Site", "workflow": "marketplace-coinbase-local-projection-import"}, roots, roots_json
             )
             self.assertEqual(result["state"], "COMPLETE")
             self.assertEqual(result["outcome"], "SOVEREIGN_LOCAL_SITE_MARKETPLACE_PROJECTION_IMPORT")


### PR DESCRIPTION
Follow-up safety gate for Healer issue #8 after canonical Site B16R1 retired the hosted workflow before the retained Site importer itself was made local-only.

PR #9 source-merged the fixed `marketplace-coinbase-local-projection-import` target, but current Site main still retains a legacy `raw.githubusercontent.com`/`urllib` importer. This patch prevents the existing sovereign scheduler from executing that legacy source.

The handler now requires the materialized Site importer to visibly bind `STEGVERSE_REPO_ROOTS_JSON` and `GCAT-BCAT-Engine/Publisher` and rejects remote URL/network markers. Otherwise it returns `SITE_MARKETPLACE_PROJECTION_LOCAL_CAPABILITY_NOT_INSTALLED` without execution. Tests cover the legacy remote importer denial, missing Publisher failure, and valid local-only execution.

No Render, no new scheduler/heartbeat, no token/PAT/provider/wallet authority, no runtime activation inference. TV/TVC remains credential authority; USER_ONLY remains sole StegFin signer/broadcaster. Site local-only source hardening continues separately against fresh current main.