### PR TITLE
Add sovereign Site B27 validation carrier

### DIFF
--- a/app/sovereign_scheduler.py
+++ b/app/sovereign_scheduler.py
@@ -128,6 +128,119 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
                 return {**base, "state": "BLOCKED", "outcome": "SITE_LOCAL_ORCHESTRATION_BLOCKED", "execution": results}
         return {**base, "state": "COMPLETE", "outcome": "SOVEREIGN_LOCAL_SITE_ORCHESTRATION", "execution": results}
 
+    if repo == "StegVerse-Labs/Site" and workflow == "site-b27-native-validation":
+        local_forbidden = (
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+            "GITHUB_PAT",
+            "TVC_EPHEMERAL_GITHUB_TOKEN",
+            "STEGVERSE_PROVIDER_TOKEN",
+            "STEGVERSE_MASTER_RECORDS_TOKEN",
+            "STEGVERSE_HIL_REVIEW_TOKEN",
+            "STEGVERSE_HIL_PUBLICATION_TOKEN",
+            "CLOUDFLARE_API_TOKEN",
+            "CLOUDFLARE_ACCOUNT_ID",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        )
+        present = [name for name in local_forbidden if os.getenv(name)]
+        if present:
+            return {**base, "state": "BLOCKED", "outcome": "SITE_B27_FORBIDDEN_CREDENTIAL_ENV", "forbidden": sorted(present)}
+
+        commands = [
+            "scripts/check_thought_experiments_publication.py",
+            "scripts/write_site_workflow_inventory.py",
+            "scripts/check_site_workflow_inventory.py",
+            "scripts/check_session_work_claims.py",
+            "scripts/site_handoff_orchestrator.py",
+            "scripts/check_ecosystem_heartbeat_orchestration.py",
+            "scripts/check_ecosystem_chat_application.py",
+            "scripts/check_iphone_heartbeat_transition_projection.py",
+            "scripts/run_sandbox_validation.py",
+            "scripts/check_stegfin_phone_projection.py",
+        ]
+        missing = [name for name in commands if not (root / name).is_file()]
+        if missing:
+            return {**base, "state": "BLOCKED", "outcome": "SITE_B27_VALIDATOR_MISSING", "missing": missing}
+
+        head_result = _run(["git", "rev-parse", "HEAD"], root, timeout=30)
+        source_head = str(head_result.get("stdout_tail", "")).strip().splitlines()[-1] if head_result["returncode"] == 0 and str(head_result.get("stdout_tail", "")).strip() else ""
+        if head_result["returncode"] != 0 or len(source_head) != 40:
+            return {**base, "state": "BLOCKED", "outcome": "SITE_B27_SOURCE_HEAD_UNPROVEN", "execution": head_result}
+
+        executions = []
+        for script in commands:
+            result = _run([sys.executable, script], root, timeout=240)
+            executions.append(result)
+            if result["returncode"] != 0:
+                return {
+                    **base,
+                    "state": "BLOCKED",
+                    "outcome": "SITE_B27_VALIDATION_BLOCKED",
+                    "source_head": source_head,
+                    "failed_script": script,
+                    "execution": executions,
+                }
+
+        thought_path = root / "thought-experiments-publication.report.json"
+        inventory_path = root / "data" / "site-workflow-inventory.json"
+        task_path = root / "data" / "tasks" / "SITE-ACTIONS-COST-CONTAINMENT-001-B27.json"
+        if not thought_path.is_file() or not inventory_path.is_file() or not task_path.is_file():
+            return {
+                **base,
+                "state": "BLOCKED",
+                "outcome": "SITE_B27_REQUIRED_RECEIPT_MISSING",
+                "source_head": source_head,
+                "execution": executions,
+            }
+
+        thought = _load_json(thought_path)
+        inventory = _load_json(inventory_path)
+        task = _load_json(task_path)
+        standalone = root / ".github" / "workflows" / "verify-thought-experiments-publication.yml"
+        complete = (
+            thought.get("state") == "PASS"
+            and thought.get("authority_effect") is False
+            and thought.get("activation_effect") is False
+            and not standalone.exists()
+            and inventory.get("canonical_count") == 3
+            and inventory.get("placeholder_count") == 0
+            and task.get("credential_authority") == "TV/TVC"
+            and task.get("non_tv_tvc_secret_or_token_allowed") is False
+            and task.get("github_actions_runtime_authority") == "NONE"
+            and task.get("render_required") is False
+        )
+        receipt = {
+            "schema": "stegverse.healer.site_b27_validation_receipt/v0.1",
+            "state": "PASS" if complete else "BLOCKED",
+            "source_head": source_head,
+            "credential_authority": "TV/TVC",
+            "github_token_required": False,
+            "remote_checkout_required": False,
+            "artifact_custody_required": False,
+            "repository_writeback_authority": False,
+            "runtime_authority": False,
+            "wallet_signing_broadcast_authority": False,
+            "publication_authority": False,
+            "settlement_authority": False,
+            "thought_experiments_publication": thought.get("state"),
+            "thought_experiments_authority_effect": thought.get("authority_effect"),
+            "thought_experiments_activation_effect": thought.get("activation_effect"),
+            "standalone_workflow_retired": not standalone.exists(),
+            "workflow_file_count": inventory.get("workflow_file_count"),
+            "canonical_count": inventory.get("canonical_count"),
+            "migration_required_operational_count": inventory.get("migration_required_operational_count"),
+            "placeholder_count": inventory.get("placeholder_count"),
+            "validated_scripts": commands,
+        }
+        return {
+            **base,
+            "state": "COMPLETE" if complete else "BLOCKED",
+            "outcome": "SOVEREIGN_LOCAL_SITE_B27_VALIDATION",
+            "source_head": source_head,
+            "execution": executions,
+            "receipt": receipt,
+        }
+
     if repo == "StegVerse-Labs/Site" and workflow == "marketplace-coinbase-local-observer":
         script = root / "scripts" / "advance_marketplace_coinbase_activation.py"
         if not script.is_file():

--- a/data/orchestrator_targets.json
+++ b/data/orchestrator_targets.json
@@ -13,6 +13,16 @@
     },
     {
       "repo": "StegVerse-Labs/Site",
+      "workflow": "site-b27-native-validation",
+      "ref": "main",
+      "enabled": true,
+      "aliases": ["site-b27", "site-b27-validation", "thought-experiments-b27"],
+      "run_hours_utc": [0, 6, 12, 18],
+      "inputs": {},
+      "status": "sovereign-local-b27-validation-no-github-token-no-remote-checkout-no-artifact-custody"
+    },
+    {
+      "repo": "StegVerse-Labs/Site",
       "workflow": "marketplace-coinbase-local-observer",
       "ref": "main",
       "enabled": true,

--- a/docs/HEALER_SITE_B27_VALIDATION_MIRROR_HANDOFF.md
+++ b/docs/HEALER_SITE_B27_VALIDATION_MIRROR_HANDOFF.md
@@ -1,0 +1,118 @@
+# Healer Site B27 Sovereign Validation Mirror Handoff
+
+This is a scoped, noncompeting child handoff for `HEALER-SITE-B27-SOVEREIGN-VALIDATION-001`. The repository-wide canonical handoff remains `docs/HEALER_MIRROR_HANDOFF.md`.
+
+## Canonical state
+
+```text
+goal_id: HEALER-SITE-B27-SOVEREIGN-VALIDATION-001
+originating_goal: provide an equal-or-stronger StegVerse-native validation path for Site B27 while GitHub-hosted validation is billing-blocked
+repository: StegVerse-Labs/StegVerse-Healer
+branch: feat/site-b27-sovereign-validation-carrier-14
+canonical_issue: StegVerse-Labs/StegVerse-Healer#14
+source_site_owner: StegVerse-Labs/Site#268
+source_site_task: data/tasks/SITE-ACTIONS-COST-CONTAINMENT-001-B27.json
+source_site_pr: StegVerse-Labs/Site#387
+credential_authority: TV/TVC
+non_tv_tvc_secret_or_token_allowed: false
+github_token_required: false
+remote_checkout_required: false
+github_artifact_custody_required: false
+render_required: false
+github_actions_production_role: NONE
+ordinary_scheduler_owner: SHWP-HEALER-SOVEREIGN-SCHEDULER-001
+second_scheduler_or_heartbeat_allowed: false
+wallet_signing_and_broadcast: USER_ONLY
+implementation_claim: CLAIMED_FOR_IMPLEMENTATION
+validation_claim: CLAIMED_FOR_VALIDATION
+claim_created_at: 2026-08-18T00:52:19Z
+claim_release_condition: source carrier and deterministic tests merged/released, or explicit BLOCKED state with machine-observable release condition
+state: SOURCE_IMPLEMENTED_VALIDATION_PENDING
+```
+
+## Authoritative surfaces
+
+- `data/orchestrator_targets.json::StegVerse-Labs/Site/site-b27-native-validation`
+- `app/sovereign_scheduler.py::_execute_target`
+- `tests/test_site_b27_native_validation.py`
+- `docs/HEALER_SITE_B27_VALIDATION_MIRROR_HANDOFF.md`
+- issue `StegVerse-Labs/StegVerse-Healer#14`
+- source continuation `StegVerse-Labs/Site#268`, Site PR #387, and Site `data/tasks/SITE-ACTIONS-COST-CONTAINMENT-001-B27.json`
+
+## Installed execution contract
+
+The new fixed target reuses the existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`; no second scheduler or heartbeat is created. It runs only against an already-materialized local `StegVerse-Labs/Site` root from `STEGVERSE_REPO_ROOTS_JSON` and never performs remote checkout.
+
+The target executes the bounded deterministic Site validators required for B27 release evidence:
+
+1. `scripts/check_thought_experiments_publication.py`
+2. `scripts/write_site_workflow_inventory.py`
+3. `scripts/check_site_workflow_inventory.py`
+4. `scripts/check_session_work_claims.py`
+5. `scripts/site_handoff_orchestrator.py`
+6. `scripts/check_ecosystem_heartbeat_orchestration.py`
+7. `scripts/check_ecosystem_chat_application.py`
+8. `scripts/check_iphone_heartbeat_transition_projection.py`
+9. `scripts/run_sandbox_validation.py`
+10. `scripts/check_stegfin_phone_projection.py`
+
+The carrier fails closed when the Site root is absent, any required validator is absent, the local Git source head cannot be proven, any validator exits nonzero, required deterministic receipts are absent, the Thought Experiments receipt is not `PASS`, authority or activation is asserted, the retired standalone workflow still exists, the workflow inventory has anything other than three canonical workflows or zero placeholders, the B27 task does not preserve TV/TVC-only credential authority, or a credential-bearing validation environment is present.
+
+Successful output is embedded in the existing sovereign scheduler receipt as `stegverse.healer.site_b27_validation_receipt/v0.1` and includes the exact local source head, workflow counts, validated script list, and explicit false values for GitHub-token requirement, remote checkout, artifact custody, repository writeback authority, runtime authority, wallet signing/broadcast authority, publication authority, and settlement authority.
+
+## Source commits
+
+```text
+target binding: 334badfaf4bcbf189a1963c970bedfcbefdd728c
+scheduler handler: 83c491650ff16be246944643b9a84e832aa676a5
+deterministic tests: cd8ea6d26b531827708c12411af7200bdc590ed8
+```
+
+## Validation
+
+Static/source inspection: COMPLETE.
+Deterministic unit test source: INSTALLED.
+Hosted Healer test execution: PENDING.
+Ordinary sovereign scheduler execution against the Site B27 materialized source: MACHINE_OWNED / PENDING.
+
+Required validation commands after source checkout/materialization:
+
+```bash
+python -m unittest tests.test_site_b27_native_validation
+python -m unittest discover -s tests
+```
+
+Strongest release evidence requires either successful Healer test execution or an equal/stronger local deterministic execution plus direct inspection. Source presence alone does not prove the live scheduler executed.
+
+## Cross-repository integration
+
+When a sovereign scheduler receipt contains a `site-b27-native-validation` outcome with `state=COMPLETE`, receipt `state=PASS`, and `source_head` exactly equal to the then-current Site B27 candidate head, Site #268 may use that as the StegVerse-native pre-merge validation carrier allowed by `data/tasks/SITE-ACTIONS-COST-CONTAINMENT-001-B27.json`. Site must still verify its own release predicates, remain current with main, merge through its canonical release path, and separately observe the post-merge Thought Experiments public routes.
+
+This carrier grants no Site merge authority and cannot sign/broadcast a StegFin wallet transaction, publish on behalf of a human, grant runtime authority, or settle a trade.
+
+## Blockers and machine-owned work
+
+- Ordinary Healer scheduler activation is MACHINE_OWNED and remains proven only by the canonical scheduler receipt `receipts/healer-sovereign-scheduler/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json`.
+- The Site B27 candidate must be locally materialized at the exact candidate head for exact-head proof.
+- GitHub-hosted CI may remain billing-blocked; this source carrier exists specifically so that GitHub billing is not the only possible validation path.
+
+## Session consolidation
+
+The user-session requirement to continue actual execution despite prior archive wording is durably represented by this issue/handoff and the Site #268 continuation. The local-model/runtime source goals remain complete/released elsewhere and are not duplicated here. StegFin signing/broadcast remains USER_ONLY.
+
+```text
+developed_files: 4/4
+validation: 1/3
+integration: 1/3
+goal_activation: 1/3
+session_consolidation: 4/5
+archive_condition: Healer source carrier released or durably blocked; Site continuation remains self-sufficient; no chat-only requirement remains
+```
+
+## Next executable actions
+
+1. Execute Healer deterministic tests on this exact branch/head through the strongest available path.
+2. Correct any source/test failure without weakening fail-closed or credential boundaries.
+3. Merge/release issue #14 only after test evidence is inspected.
+4. Wait for the existing sovereign scheduler machine lane to execute `site-b27-native-validation` against the exact materialized Site B27 head.
+5. Propagate a matching PASS receipt to Site #268 / B27 task; Site then completes its own merge and post-merge public-route proof.

--- a/tests/test_site_b27_native_validation.py
+++ b/tests/test_site_b27_native_validation.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app import sovereign_scheduler
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSiteB27NativeValidation(unittest.TestCase):
+    def target(self) -> dict:
+        config = json.loads((ROOT / "data" / "orchestrator_targets.json").read_text(encoding="utf-8"))
+        matches = [
+            target for target in config["targets"]
+            if target.get("repo") == "StegVerse-Labs/Site"
+            and target.get("workflow") == "site-b27-native-validation"
+        ]
+        self.assertEqual(len(matches), 1)
+        return matches[0]
+
+    def test_target_reuses_existing_scheduler_without_token_or_remote_checkout(self):
+        target = self.target()
+        self.assertEqual(target["run_hours_utc"], [0, 6, 12, 18])
+        self.assertIn("site-b27-validation", target["aliases"])
+        serialized = json.dumps(target).lower()
+        self.assertIn("no-github-token", serialized)
+        self.assertIn("no-remote-checkout", serialized)
+        self.assertIn("no-artifact-custody", serialized)
+
+    def test_missing_validator_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            site.mkdir()
+            roots = {"StegVerse-Labs/Site": site}
+            result = sovereign_scheduler._execute_target(
+                {"repo": "StegVerse-Labs/Site", "workflow": "site-b27-native-validation"},
+                roots,
+                json.dumps({key: str(value) for key, value in roots.items()}),
+            )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_B27_VALIDATOR_MISSING")
+
+    def _build_fake_site(self, root: Path) -> None:
+        scripts = [
+            "check_thought_experiments_publication.py",
+            "write_site_workflow_inventory.py",
+            "check_site_workflow_inventory.py",
+            "check_session_work_claims.py",
+            "site_handoff_orchestrator.py",
+            "check_ecosystem_heartbeat_orchestration.py",
+            "check_ecosystem_chat_application.py",
+            "check_iphone_heartbeat_transition_projection.py",
+            "run_sandbox_validation.py",
+            "check_stegfin_phone_projection.py",
+        ]
+        (root / "scripts").mkdir(parents=True)
+        for name in scripts:
+            (root / "scripts" / name).write_text("raise SystemExit(0)\n", encoding="utf-8")
+        (root / "data" / "tasks").mkdir(parents=True)
+        (root / ".github" / "workflows").mkdir(parents=True)
+        (root / "data" / "tasks" / "SITE-ACTIONS-COST-CONTAINMENT-001-B27.json").write_text(
+            json.dumps({
+                "credential_authority": "TV/TVC",
+                "non_tv_tvc_secret_or_token_allowed": False,
+                "github_actions_runtime_authority": "NONE",
+                "render_required": False,
+            }),
+            encoding="utf-8",
+        )
+
+    def test_pass_receipt_requires_exact_local_head_and_non_authorizing_evidence(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            self._build_fake_site(site)
+            roots = {"StegVerse-Labs/Site": site}
+            head = "a" * 40
+
+            def fake_run(command, cwd, env_extra=None, timeout=180):
+                if command[:3] == ["git", "rev-parse", "HEAD"]:
+                    return {"command": command, "returncode": 0, "stdout_tail": head + "\n", "stderr_tail": ""}
+                script = command[-1]
+                if script == "scripts/check_thought_experiments_publication.py":
+                    (site / "thought-experiments-publication.report.json").write_text(
+                        json.dumps({"state": "PASS", "authority_effect": False, "activation_effect": False}),
+                        encoding="utf-8",
+                    )
+                if script == "scripts/write_site_workflow_inventory.py":
+                    (site / "data" / "site-workflow-inventory.json").write_text(
+                        json.dumps({
+                            "workflow_file_count": 97,
+                            "canonical_count": 3,
+                            "migration_required_operational_count": 94,
+                            "placeholder_count": 0,
+                        }),
+                        encoding="utf-8",
+                    )
+                return {"command": command, "returncode": 0, "stdout_tail": "PASS\n", "stderr_tail": ""}
+
+            with patch.object(sovereign_scheduler, "_run", side_effect=fake_run):
+                result = sovereign_scheduler._execute_target(
+                    {"repo": "StegVerse-Labs/Site", "workflow": "site-b27-native-validation"},
+                    roots,
+                    json.dumps({key: str(value) for key, value in roots.items()}),
+                )
+
+            self.assertEqual(result["state"], "COMPLETE")
+            self.assertEqual(result["outcome"], "SOVEREIGN_LOCAL_SITE_B27_VALIDATION")
+            receipt = result["receipt"]
+            self.assertEqual(receipt["state"], "PASS")
+            self.assertEqual(receipt["source_head"], head)
+            self.assertEqual(receipt["credential_authority"], "TV/TVC")
+            self.assertIs(receipt["github_token_required"], False)
+            self.assertIs(receipt["remote_checkout_required"], False)
+            self.assertIs(receipt["artifact_custody_required"], False)
+            self.assertIs(receipt["repository_writeback_authority"], False)
+            self.assertIs(receipt["runtime_authority"], False)
+            self.assertIs(receipt["wallet_signing_broadcast_authority"], False)
+            self.assertIs(receipt["publication_authority"], False)
+            self.assertIs(receipt["settlement_authority"], False)
+            self.assertEqual(receipt["workflow_file_count"], 97)
+            self.assertEqual(receipt["canonical_count"], 3)
+            self.assertEqual(receipt["migration_required_operational_count"], 94)
+            self.assertEqual(receipt["placeholder_count"], 0)
+
+    def test_validator_failure_blocks(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            self._build_fake_site(site)
+            roots = {"StegVerse-Labs/Site": site}
+
+            def fake_run(command, cwd, env_extra=None, timeout=180):
+                if command[:3] == ["git", "rev-parse", "HEAD"]:
+                    return {"command": command, "returncode": 0, "stdout_tail": "b" * 40 + "\n", "stderr_tail": ""}
+                return {"command": command, "returncode": 1, "stdout_tail": "", "stderr_tail": "blocked"}
+
+            with patch.object(sovereign_scheduler, "_run", side_effect=fake_run):
+                result = sovereign_scheduler._execute_target(
+                    {"repo": "StegVerse-Labs/Site", "workflow": "site-b27-native-validation"},
+                    roots,
+                    json.dumps({key: str(value) for key, value in roots.items()}),
+                )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_B27_VALIDATION_BLOCKED")
+
+    def test_credential_bearing_environment_blocks(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            self._build_fake_site(site)
+            roots = {"StegVerse-Labs/Site": site}
+            with patch.dict(os.environ, {"GITHUB_TOKEN": "forbidden"}, clear=False):
+                result = sovereign_scheduler._execute_target(
+                    {"repo": "StegVerse-Labs/Site", "workflow": "site-b27-native-validation"},
+                    roots,
+                    json.dumps({key: str(value) for key, value in roots.items()}),
+                )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_B27_FORBIDDEN_CREDENTIAL_ENV")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes/implements Healer #14 source carrier.

This PR adds a fixed `site-b27-native-validation` target to the existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`. It consumes only an already-materialized Site root, proves the exact local Git head, executes the bounded deterministic Site B27 validators, and returns an inspectable non-authorizing receipt.

Boundaries:
- TV/TVC credential authority only;
- no NON-TV/TVC/GitHub credential path;
- no Render;
- no remote checkout;
- no GitHub artifact custody;
- no repository writeback authority;
- no second scheduler/heartbeat;
- no runtime authority;
- StegFin signing/broadcast remains USER_ONLY;
- no publication or settlement authority.

Canonical scoped handoff: `docs/HEALER_SITE_B27_VALIDATION_MIRROR_HANDOFF.md`.
Canonical Site continuation: `StegVerse-Labs/Site#268`, Site PR #387, and `data/tasks/SITE-ACTIONS-COST-CONTAINMENT-001-B27.json`.

Merge only after deterministic Healer test evidence is inspected. Source merge does not prove ordinary scheduler activation.