### PR TITLE
feat: add sovereign StegFin publication observer

### DIFF
--- a/app/sovereign_scheduler.py
+++ b/app/sovereign_scheduler.py
@@ -172,26 +172,13 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
             result = _run([sys.executable, script], root, timeout=240)
             executions.append(result)
             if result["returncode"] != 0:
-                return {
-                    **base,
-                    "state": "BLOCKED",
-                    "outcome": "SITE_B27_VALIDATION_BLOCKED",
-                    "source_head": source_head,
-                    "failed_script": script,
-                    "execution": executions,
-                }
+                return {**base, "state": "BLOCKED", "outcome": "SITE_B27_VALIDATION_BLOCKED", "source_head": source_head, "failed_script": script, "execution": executions}
 
         thought_path = root / "thought-experiments-publication.report.json"
         inventory_path = root / "data" / "site-workflow-inventory.json"
         task_path = root / "data" / "tasks" / "SITE-ACTIONS-COST-CONTAINMENT-001-B27.json"
         if not thought_path.is_file() or not inventory_path.is_file() or not task_path.is_file():
-            return {
-                **base,
-                "state": "BLOCKED",
-                "outcome": "SITE_B27_REQUIRED_RECEIPT_MISSING",
-                "source_head": source_head,
-                "execution": executions,
-            }
+            return {**base, "state": "BLOCKED", "outcome": "SITE_B27_REQUIRED_RECEIPT_MISSING", "source_head": source_head, "execution": executions}
 
         thought = _load_json(thought_path)
         inventory = _load_json(inventory_path)
@@ -232,14 +219,7 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
             "placeholder_count": inventory.get("placeholder_count"),
             "validated_scripts": commands,
         }
-        return {
-            **base,
-            "state": "COMPLETE" if complete else "BLOCKED",
-            "outcome": "SOVEREIGN_LOCAL_SITE_B27_VALIDATION",
-            "source_head": source_head,
-            "execution": executions,
-            "receipt": receipt,
-        }
+        return {**base, "state": "COMPLETE" if complete else "BLOCKED", "outcome": "SOVEREIGN_LOCAL_SITE_B27_VALIDATION", "source_head": source_head, "execution": executions, "receipt": receipt}
 
     if repo == "StegVerse-Labs/Site" and workflow == "marketplace-coinbase-local-observer":
         script = root / "scripts" / "advance_marketplace_coinbase_activation.py"
@@ -274,12 +254,7 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
             return {**base, "state": "BLOCKED", "outcome": "SITE_CHILD_SAFETY_OBSERVER_MISSING"}
         with tempfile.TemporaryDirectory(prefix="stegverse-child-safety-") as temp_dir:
             receipt_path = Path(temp_dir) / "child-safety-public-deployment.report.json"
-            result = _run(
-                [sys.executable, str(script.relative_to(root))],
-                root,
-                {"STEGVERSE_CHILD_SAFETY_REPORT": str(receipt_path)},
-                timeout=60,
-            )
+            result = _run([sys.executable, str(script.relative_to(root))], root, {"STEGVERSE_CHILD_SAFETY_REPORT": str(receipt_path)}, timeout=60)
             payload = json.loads(receipt_path.read_text(encoding="utf-8")) if receipt_path.is_file() else None
         if result["returncode"] != 0 or not payload:
             return {**base, "state": "BLOCKED", "outcome": "SITE_CHILD_SAFETY_PUBLIC_ROUTE_BLOCKED", "execution": result, "receipt": payload}
@@ -289,10 +264,52 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
             and payload.get("github_token_required") is False
             and payload.get("artifact_custody_required") is False
         )
+        return {**base, "state": "COMPLETE" if complete else "BLOCKED", "outcome": "SOVEREIGN_LOCAL_SITE_CHILD_SAFETY_PUBLIC_OBSERVATION", "execution": result, "receipt": payload}
+
+    if repo == "StegVerse-Labs/Site" and workflow == "stegfin-public-wallet-transport-observer":
+        local_forbidden = (
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+            "GITHUB_PAT",
+            "TVC_EPHEMERAL_GITHUB_TOKEN",
+            "STEGVERSE_PROVIDER_TOKEN",
+            "STEGVERSE_MASTER_RECORDS_TOKEN",
+            "CLOUDFLARE_API_TOKEN",
+            "CLOUDFLARE_ACCOUNT_ID",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        )
+        present = [name for name in local_forbidden if os.getenv(name)]
+        if present:
+            return {**base, "state": "BLOCKED", "outcome": "SITE_STEGFIN_PUBLICATION_FORBIDDEN_CREDENTIAL_ENV", "forbidden": sorted(present)}
+        script = root / "scripts" / "check_stegfin_public_wallet_transport.py"
+        if not script.is_file():
+            return {**base, "state": "BLOCKED", "outcome": "SITE_STEGFIN_PUBLICATION_OBSERVER_MISSING"}
+        with tempfile.TemporaryDirectory(prefix="stegverse-stegfin-publication-") as temp_dir:
+            receipt_path = Path(temp_dir) / "stegfin-public-wallet-transport.report.json"
+            result = _run(
+                [sys.executable, str(script.relative_to(root))],
+                root,
+                {"STEGFIN_PUBLICATION_REPORT": str(receipt_path)},
+                timeout=60,
+            )
+            payload = json.loads(receipt_path.read_text(encoding="utf-8")) if receipt_path.is_file() else None
+        if result["returncode"] != 0 or not payload:
+            return {**base, "state": "BLOCKED", "outcome": "SITE_STEGFIN_PUBLICATION_OBSERVATION_BLOCKED", "execution": result, "receipt": payload}
+        complete = (
+            payload.get("state") == "VERIFIED_PUBLICATION"
+            and payload.get("publication_proven") is True
+            and payload.get("observed_ui_blob") == "114b3c39052d5b1622407080407259a0040a1369"
+            and payload.get("credential_authority") == "TV/TVC"
+            and payload.get("credential_requirement") == "NONE"
+            and payload.get("non_tv_tvc_secret_or_token_used") is False
+            and payload.get("github_token_required") is False
+            and payload.get("render_required") is False
+            and payload.get("authority_effect") is False
+        )
         return {
             **base,
             "state": "COMPLETE" if complete else "BLOCKED",
-            "outcome": "SOVEREIGN_LOCAL_SITE_CHILD_SAFETY_PUBLIC_OBSERVATION",
+            "outcome": "SOVEREIGN_LOCAL_SITE_STEGFIN_PUBLICATION_OBSERVATION",
             "execution": result,
             "receipt": payload,
         }
@@ -318,11 +335,7 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
             return {**base, "state": "BLOCKED", "outcome": "TVC_LOCAL_REPOSITORY_NOT_MATERIALIZED"}
         with tempfile.TemporaryDirectory(prefix="stegverse-tv-heal-") as temp_dir:
             receipt_path = Path(temp_dir) / "tv-self-heal.json"
-            result = _run([sys.executable, "scripts/sovereign_self_heal.py"], root, {
-                "STEGVERSE_TV_ROOT": str(root),
-                "STEGVERSE_TVC_ROOT": str(tvc_root),
-                "TV_SELF_HEAL_RECEIPT": str(receipt_path),
-            }, timeout=180)
+            result = _run([sys.executable, "scripts/sovereign_self_heal.py"], root, {"STEGVERSE_TV_ROOT": str(root), "STEGVERSE_TVC_ROOT": str(tvc_root), "TV_SELF_HEAL_RECEIPT": str(receipt_path)}, timeout=180)
             payload = json.loads(receipt_path.read_text(encoding="utf-8")) if receipt_path.is_file() else _json_tail(result)
         state = "COMPLETE" if result["returncode"] == 0 and payload and payload.get("state") == "COMPLETE" else "BLOCKED"
         return {**base, "state": state, "outcome": "TVC_GRANTED_LOCAL_TV_SELF_HEAL", "receipt": payload, "execution": result}
@@ -334,11 +347,7 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
     if repo == "StegVerse-Labs/StegVerse-Healer" and workflow == "quiet_enforcer.yml":
         with tempfile.TemporaryDirectory(prefix="stegverse-quiet-") as temp_dir:
             receipt = Path(temp_dir) / "quiet.json"
-            result = _run([sys.executable, "app/audit_schedules.py"], root, {
-                "TARGETS_FILE": str(root / "data/orchestrator_targets.json"),
-                "QUIET_RECEIPT": str(receipt),
-                "STEGVERSE_REPO_ROOTS_JSON": all_roots_json,
-            }, timeout=90)
+            result = _run([sys.executable, "app/audit_schedules.py"], root, {"TARGETS_FILE": str(root / "data/orchestrator_targets.json"), "QUIET_RECEIPT": str(receipt), "STEGVERSE_REPO_ROOTS_JSON": all_roots_json}, timeout=90)
             payload = json.loads(receipt.read_text(encoding="utf-8")) if receipt.is_file() else None
         state = "COMPLETE" if result["returncode"] == 0 and payload and payload.get("state") == "COMPLETE" else "BLOCKED"
         return {**base, "state": state, "outcome": "SOVEREIGN_LOCAL_QUIET_ENFORCER", "receipt": payload, "execution": result}

--- a/data/orchestrator_targets.json
+++ b/data/orchestrator_targets.json
@@ -52,6 +52,16 @@
       "status": "sovereign-local-hourly-public-route-observer-no-github-token-no-artifact-custody"
     },
     {
+      "repo": "StegVerse-Labs/Site",
+      "workflow": "stegfin-public-wallet-transport-observer",
+      "ref": "main",
+      "enabled": true,
+      "aliases": ["site-stegfin-publication", "stegfin-wallet-publication", "stegfin-public-wallet-transport"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "inputs": {},
+      "status": "sovereign-local-hourly-stegfin-publication-observer-no-github-token-no-artifact-custody-no-wallet-authority"
+    },
+    {
       "repo": "StegVerse-Labs/repo-standards",
       "workflow": "st018-local-task-manager",
       "ref": "main",

--- a/docs/HEALER_STEGFIN_PUBLICATION_OBSERVER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_STEGFIN_PUBLICATION_OBSERVER_MIRROR_HANDOFF.md
@@ -6,17 +6,19 @@
 goal_id: HEALER-STEGFIN-PUBLIC-WALLET-TRANSPORT-001
 originating_session_goal: make the StegFin trade path release-ready without Render or NON-TV/TVC credentials by proving the merged Site wallet-browser compatibility projection is actually public before current-phone USER_ONLY continuation
 repository: StegVerse-Labs/StegVerse-Healer
-branch: main
+branch: feat/stegfin-public-wallet-transport-observer-17
+canonical_issue: StegVerse-Labs/StegVerse-Healer#17
 source_site_owner: StegVerse-Labs/Site#388
 source_site_handoff: StegVerse-Labs/Site/docs/STEGFIN_PHONE_PROJECTION_MIRROR_HANDOFF.md
 source_site_observer: StegVerse-Labs/Site/scripts/check_stegfin_public_wallet_transport.py
+source_site_observer_scheduler_path_commit: 6d7ad7a99091dc5c0ff134b5a2f4c79b49b60034
 source_site_merge: ec8b5136ff9281ea37e861281f9428c7c283fbe4
 expected_public_ui_blob: 114b3c39052d5b1622407080407259a0040a1369
 canonical_scheduler: SHWP-HEALER-SOVEREIGN-SCHEDULER-001
-implementation_claim: CLAIMED_FOR_IMPLEMENTATION
+implementation_claim: COMPLETE_ON_BRANCH_PENDING_RELEASE
 validation_claim: CLAIMED_FOR_VALIDATION
 claim_created_at: 2026-08-18T01:40:00Z
-claim_release_condition: fixed target executes the Site publication observer through the existing sovereign scheduler and emits COMPLETE with nested VERIFIED_PUBLICATION receipt for the exact expected UI blob
+claim_release_condition: fixed target and handler pass deterministic validation, merge to main, then existing sovereign scheduler emits COMPLETE with nested VERIFIED_PUBLICATION receipt for the exact expected UI blob
 credential_authority: TV/TVC
 credential_requirement: NONE
 non_tv_tvc_secret_or_token_allowed: false
@@ -26,23 +28,28 @@ artifact_custody_required: false
 render_required: false
 wallet_signing_and_broadcast: USER_ONLY
 second_scheduler_or_heartbeat_allowed: false
-state: ACTIVE_IMPLEMENTATION
+state: IMPLEMENTED_PENDING_VALIDATION_RELEASE
 ```
 
 ## Collision and authority boundaries
 
-This task must reuse the existing sovereign Healer scheduler. Do not create a second scheduler, heartbeat, hosted runtime, GitHub-token path, wallet relay, wallet signing path, or broadcast path. The observer only performs public HTTPS verification of the Site participant and exact public UI blob. It grants no publication authority, transaction authority, wallet authority, settlement authority, or runtime authority.
+This task reuses the existing sovereign Healer scheduler. No second scheduler, heartbeat, hosted runtime, GitHub-token path, wallet relay, wallet signing path, or broadcast path is introduced. The observer only performs public HTTPS verification of the Site participant and exact public UI blob. It grants no publication authority, transaction authority, wallet authority, settlement authority, or runtime authority.
 
-## Required implementation
+## Implemented surfaces
 
 ```text
 data/orchestrator_targets.json::StegVerse-Labs/Site/stegfin-public-wallet-transport-observer
+  commit: 341b58d55a6abc5109268f1fb497439077843d3a
 app/sovereign_scheduler.py::_execute_target fixed handler
+  commit: efcde0f5b16981273a1ba5dd1c7ff6a7e9659ee0
 tests/test_site_stegfin_public_wallet_transport_observer.py
+  commit: d8e3dcea6677de85561d55361d2b5125c7c0dbe7
 this handoff
 ```
 
-The fixed target must execute the already-released Site script `scripts/check_stegfin_public_wallet_transport.py` only against an already-materialized local Site root from `STEGVERSE_REPO_ROOTS_JSON`. No remote checkout is allowed. The Site script itself performs credential-free public HTTPS observation of `stegverse.org` and writes its result to an ephemeral/local receipt path supplied by Healer.
+The fixed target executes the released Site script `scripts/check_stegfin_public_wallet_transport.py` only against an already-materialized local Site root from `STEGVERSE_REPO_ROOTS_JSON`. No remote checkout is performed. The Site observer writes to an ephemeral receipt path supplied by the scheduler and accepts both the canonical `STEGVERSE_STEGFIN_PUBLICATION_REPORT` variable and the scheduler-local `STEGFIN_PUBLICATION_REPORT` alias; Site commit `6d7ad7a99091dc5c0ff134b5a2f4c79b49b60034` installed that deterministic path compatibility.
+
+The scheduler handler refuses credential-bearing environments before invoking the observer. The refusal set includes GitHub credentials, TVC ephemeral GitHub token material, provider/master-records token paths, Cloudflare credentials, and Actions OIDC request material. Missing Site materialization and missing observer script fail closed.
 
 ## Required completion predicate
 
@@ -51,6 +58,7 @@ A scheduler outcome is COMPLETE only when all are true:
 ```text
 Site root materialized locally
 Site observer script present
+credential-bearing environment absent
 observer process exits 0
 nested receipt state == VERIFIED_PUBLICATION
 nested publication_proven == true
@@ -63,7 +71,17 @@ nested render_required == false
 nested authority_effect == false
 ```
 
-Any mismatch is BLOCKED. No current-phone activation is inferred from this observer.
+Any mismatch is BLOCKED. No current-phone activation, wallet signing, broadcast, publication authority, or settlement is inferred from this observer.
+
+## Deterministic test contract
+
+`tests/test_site_stegfin_public_wallet_transport_observer.py` covers:
+
+1. fixed target is hourly on the existing scheduler;
+2. missing observer script fails closed;
+3. credential-bearing environment fails closed before execution;
+4. exact `VERIFIED_PUBLICATION` + expected blob completes without authority;
+5. wrong blob and nonzero observer execution block.
 
 ## Cross-repository continuation
 
@@ -75,6 +93,8 @@ StegVerse-Labs/Site#388
 -> current phone USER_ONLY: Safari fail-closed -> local wallet-browser reopen -> NEW PREPARE -> governed injected provider -> wallet review
 ```
 
+The original local-model/runtime goal remains complete and machine-owned elsewhere; this task does not duplicate it.
+
 ## Validation commands
 
 ```text
@@ -82,16 +102,29 @@ python -m unittest -q tests.test_site_stegfin_public_wallet_transport_observer
 python -m unittest -q
 ```
 
+No validation PASS is claimed until an execution surface directly reports it.
+
 ## Completion accounting
 
 ```text
-developed_files: 1/4
-validation: 0/2
-integration: 0/2
-goal_activation: 0/2
-session_consolidation: all session requirements already durable in Site #388 and StegFin #81; this handoff owns only the noncompeting sovereign publication-observer carrier
+developed_files: 4/4
+scaffolding_or_stubs: 0
+missing_required_files: 0
+validation: 0/2 pending execution
+integration: 1/2 source surfaces integrated on branch; main release pending
+goal_activation: 0/2 source release + machine receipt both required
+session_consolidation: all unique session requirements durable in Site #388, StegFin #81, Healer #17, and this handoff
 ```
+
+## Exact next actions
+
+1. Open Healer #17 pull request from `feat/stegfin-public-wallet-transport-observer-17` to `main`.
+2. Inspect Test Readiness/repository validation jobs and logs; require deterministic observer tests to execute and pass.
+3. Merge only if the branch remains mergeable/current and validation evidence is sufficient.
+4. Existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001` executes the released fixed target against a materialized current Site root.
+5. Accept publication proof only from a scheduler outcome `COMPLETE` whose nested receipt is `VERIFIED_PUBLICATION` for blob `114b3c39052d5b1622407080407259a0040a1369`.
+6. Propagate that proof to Site #388 and StegFin #81, then release this implementation claim; current-phone proof remains USER_ONLY.
 
 ## Archive condition
 
-This scoped task is archive-safe only after the fixed target, scheduler handler, deterministic tests, and release evidence are complete or continuation is durably transferred to the existing machine-owned scheduler. Live current-phone signing/broadcast remains outside Healer and USER_ONLY.
+This scoped implementation becomes archive-safe after source release and durable machine-owned continuation are proven. Current-phone signing/broadcast remains outside Healer and USER_ONLY. If source is released but the machine receipt is pending, continuation may be transferred to the existing scheduler only when its target, acceptance predicate, and downstream owner are all durably recorded.

--- a/tests/test_site_stegfin_public_wallet_transport_observer.py
+++ b/tests/test_site_stegfin_public_wallet_transport_observer.py
@@ -47,7 +47,7 @@ class TestSiteStegFinPublicWalletTransportObserver(unittest.TestCase):
     def test_target_is_hourly_on_existing_scheduler(self):
         target = self.target()
         self.assertEqual(target["run_hours_utc"], list(range(24)))
-        self.assertIn("stegfin-publication", target["aliases"])
+        self.assertIn("site-stegfin-publication", target["aliases"])
         self.assertIn("no-github-token", target["status"])
         self.assertIn("no-wallet-authority", target["status"])
 

--- a/tests/test_site_stegfin_public_wallet_transport_observer.py
+++ b/tests/test_site_stegfin_public_wallet_transport_observer.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from app import sovereign_scheduler
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_BLOB = "114b3c39052d5b1622407080407259a0040a1369"
+
+
+class TestSiteStegFinPublicWalletTransportObserver(unittest.TestCase):
+    def target(self) -> dict:
+        config = json.loads((ROOT / "data" / "orchestrator_targets.json").read_text(encoding="utf-8"))
+        matches = [
+            target for target in config["targets"]
+            if target.get("repo") == "StegVerse-Labs/Site"
+            and target.get("workflow") == "stegfin-public-wallet-transport-observer"
+        ]
+        self.assertEqual(len(matches), 1)
+        return matches[0]
+
+    def execute(self, site: Path) -> dict:
+        roots = {"StegVerse-Labs/Site": site}
+        return sovereign_scheduler._execute_target(
+            {"repo": "StegVerse-Labs/Site", "workflow": "stegfin-public-wallet-transport-observer"},
+            roots,
+            json.dumps({key: str(value) for key, value in roots.items()}),
+        )
+
+    def install_script(self, site: Path, payload: dict, exit_code: int = 0) -> None:
+        scripts = site / "scripts"
+        scripts.mkdir(parents=True, exist_ok=True)
+        (scripts / "check_stegfin_public_wallet_transport.py").write_text(
+            "import json, os\n"
+            "from pathlib import Path\n"
+            "p=Path(os.environ['STEGFIN_PUBLICATION_REPORT'])\n"
+            f"p.write_text(json.dumps({payload!r}))\n"
+            f"raise SystemExit({exit_code})\n",
+            encoding="utf-8",
+        )
+
+    def test_target_is_hourly_on_existing_scheduler(self):
+        target = self.target()
+        self.assertEqual(target["run_hours_utc"], list(range(24)))
+        self.assertIn("stegfin-publication", target["aliases"])
+        self.assertIn("no-github-token", target["status"])
+        self.assertIn("no-wallet-authority", target["status"])
+
+    def test_missing_script_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            site.mkdir()
+            result = self.execute(site)
+        self.assertEqual(result["state"], "BLOCKED")
+        self.assertEqual(result["outcome"], "SITE_STEGFIN_PUBLICATION_OBSERVER_MISSING")
+
+    def test_credential_bearing_environment_fails_closed_before_execution(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            self.install_script(site, {})
+            with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "forbidden"}, clear=False):
+                result = self.execute(site)
+        self.assertEqual(result["state"], "BLOCKED")
+        self.assertEqual(result["outcome"], "SITE_STEGFIN_PUBLICATION_FORBIDDEN_CREDENTIAL_ENV")
+        self.assertIn("GITHUB_TOKEN", result["forbidden"])
+
+    def test_exact_verified_publication_completes_without_authority(self):
+        payload = {
+            "state": "VERIFIED_PUBLICATION",
+            "publication_proven": True,
+            "observed_ui_blob": EXPECTED_BLOB,
+            "credential_authority": "TV/TVC",
+            "credential_requirement": "NONE",
+            "non_tv_tvc_secret_or_token_used": False,
+            "github_token_required": False,
+            "render_required": False,
+            "authority_effect": False,
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            self.install_script(site, payload)
+            result = self.execute(site)
+        self.assertEqual(result["state"], "COMPLETE")
+        self.assertEqual(result["outcome"], "SOVEREIGN_LOCAL_SITE_STEGFIN_PUBLICATION_OBSERVATION")
+        self.assertIs(result["receipt"]["authority_effect"], False)
+        self.assertIs(result["receipt"]["github_token_required"], False)
+        self.assertEqual(result["receipt"]["credential_authority"], "TV/TVC")
+
+    def test_wrong_blob_or_nonzero_observer_blocks(self):
+        payload = {
+            "state": "VERIFIED_PUBLICATION",
+            "publication_proven": True,
+            "observed_ui_blob": "wrong",
+            "credential_authority": "TV/TVC",
+            "credential_requirement": "NONE",
+            "non_tv_tvc_secret_or_token_used": False,
+            "github_token_required": False,
+            "render_required": False,
+            "authority_effect": False,
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            self.install_script(site, payload)
+            wrong_blob = self.execute(site)
+            self.install_script(site, payload, exit_code=1)
+            nonzero = self.execute(site)
+        self.assertEqual(wrong_blob["state"], "BLOCKED")
+        self.assertEqual(wrong_blob["outcome"], "SOVEREIGN_LOCAL_SITE_STEGFIN_PUBLICATION_OBSERVATION")
+        self.assertEqual(nonzero["state"], "BLOCKED")
+        self.assertEqual(nonzero["outcome"], "SITE_STEGFIN_PUBLICATION_OBSERVATION_BLOCKED")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements StegVerse-Healer #17 / HEALER-STEGFIN-PUBLIC-WALLET-TRANSPORT-001.

- Reuses existing SHWP-HEALER-SOVEREIGN-SCHEDULER-001; no second scheduler or heartbeat.
- Adds fixed Site target `stegfin-public-wallet-transport-observer`.
- Executes the credential-free Site observer against an already-materialized Site root only.
- Accepts COMPLETE only for nested VERIFIED_PUBLICATION with exact UI blob `114b3c39052d5b1622407080407259a0040a1369`.
- Refuses GitHub/provider/Cloudflare credential-bearing environments.
- No remote checkout, artifact custody, Render runtime, publication authority, wallet authority, signing, broadcast, or settlement authority.
- Adds deterministic fail-closed tests and updates the scoped mirror handoff.

Current-phone USER_ONLY proof remains downstream in StegFin #81 after publication proof.