### PR TITLE
Validate failure mailbox benchmark package gate

### DIFF
--- a/failure_mailbox/benchmark-validation-request.json
+++ b/failure_mailbox/benchmark-validation-request.json
@@ -1,0 +1,15 @@
+{
+  "schema": "stegverse.healer.failure-mailbox-benchmark-validation-request/v0.1",
+  "goal_id": "HEALER-GITHUB-FAILURE-MAILBOX-001",
+  "benchmark_id": "FAILURE-MAILBOX-BENCHMARK-001",
+  "requested_validation": [
+    "deterministic_healer_tests",
+    "failure_mailbox_product_benchmark",
+    "validation_only_authority_boundary"
+  ],
+  "package_release_allowed": false,
+  "historical_corpus_benchmark_required": true,
+  "live_incremental_benchmark_required": true,
+  "credential_authority": "TV/TVC",
+  "github_token_production_authority": "NONE"
+}


### PR DESCRIPTION
Validation experiment outcome: hosted Test Readiness remains unsuitable for current private Healer source under the TV/TVC_ONLY / no GitHub-token boundary because its exact-source step is anonymous. The failure-mailbox benchmark must execute on the existing sovereign Healer local scheduler. This PR is closed as a bounded validation experiment; no package or runtime claim is made.