### PR TITLE
Validate failure mailbox benchmark v0.2

### DIFF
--- a/data/validation/failure-mailbox-benchmark-v2.json
+++ b/data/validation/failure-mailbox-benchmark-v2.json
@@ -1,0 +1,17 @@
+{
+  "schema": "stegverse.healer.failure-mailbox-benchmark-validation-request/v0.2",
+  "goal_id": "HEALER-GITHUB-FAILURE-MAILBOX-001",
+  "benchmark_schema": "stegverse.healer.failure-mailbox-benchmark/v0.2",
+  "required_checks": [
+    "deterministic_healer_tests",
+    "github_notification_parser_tests",
+    "failure_episode_analysis_tests",
+    "failure_mailbox_product_benchmark",
+    "validation_only_authority_boundary"
+  ],
+  "package_release_allowed": false,
+  "historical_corpus_benchmark_required": true,
+  "live_incremental_benchmark_required": true,
+  "credential_authority": "TV/TVC",
+  "github_token_production_authority": "NONE"
+}

--- a/failure_mailbox/benchmark.py
+++ b/failure_mailbox/benchmark.py
@@ -2,8 +2,13 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from failure_mailbox.episode_analysis import build_failure_episodes, episode_summary
 from failure_mailbox.incident_engine import (
@@ -14,7 +19,6 @@ from failure_mailbox.incident_engine import (
     transition_incident,
 )
 
-ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = ROOT / "failure_mailbox" / "benchmark_fixtures.json"
 
 


### PR DESCRIPTION
Bounded exact-head validation of the repaired deterministic test suite plus failure-mailbox parser, episode analysis, and benchmark v0.2. Reuses the existing validation-only Test Readiness surface. No runtime, mailbox, repair, release, credential, or heartbeat authority is granted.