### PR TITLE
Validate positive failure amplification detection

### DIFF
--- a/data/validation/failure-mailbox-amplification-v3.json
+++ b/data/validation/failure-mailbox-amplification-v3.json
@@ -1,0 +1,16 @@
+{
+  "schema": "stegverse.healer.failure-mailbox-amplification-validation/v0.1",
+  "goal_id": "HEALER-GITHUB-FAILURE-MAILBOX-001",
+  "benchmark_schema": "stegverse.healer.failure-mailbox-benchmark/v0.3",
+  "required": [
+    "all deterministic tests pass",
+    "benchmark result PASS",
+    "positive amplification episode detected",
+    "multi-workflow fanout preserved without incident collapse",
+    "package release remains prohibited"
+  ],
+  "credential_authority": "TV/TVC",
+  "github_token_production_authority": "NONE",
+  "runtime_authority": false,
+  "package_release_allowed": false
+}


### PR DESCRIPTION
Validation completed successfully. Test Readiness run 32213344735 / job 95950152346 passed all 44 tests and benchmark v0.3. Positive amplification detection passed: 1 amplification episode, largest notification episode 2, largest workflow fanout 2, while distinct incidents remained preserved. The underlying tuned fixture/benchmark source was already on main; this marker-only PR is closed without merge to avoid adding validation-only repository noise. Package release remains gated on historical corpus and live incremental evidence.