### PR TITLE
Validate historical failure backfill engine

### DIFF
--- a/data/validation/failure-mailbox-backfill-v1.json
+++ b/data/validation/failure-mailbox-backfill-v1.json
@@ -1,0 +1,16 @@
+{
+  "schema": "stegverse.healer.failure-mailbox-backfill-validation/v0.1",
+  "goal_id": "HEALER-GITHUB-FAILURE-MAILBOX-001",
+  "required": [
+    "historical backfill tests pass",
+    "invalid and unsupported messages quarantine",
+    "duplicate replay remains no-op",
+    "failure episodes preserve incident identity",
+    "mailbox mutation remains false",
+    "failure mailbox benchmark remains PASS"
+  ],
+  "credential_authority": "TV/TVC",
+  "github_token_production_authority": "NONE",
+  "runtime_authority": false,
+  "package_release_allowed": false
+}


### PR DESCRIPTION
Validation completed successfully. Test Readiness run 32213451011 / job 95950459271 passed 47/47 deterministic tests, including historical backfill replay/quarantine/episode tests, and benchmark v0.3 remained PASS with positive amplification detection. The underlying backfill source was already committed to main; this marker-only PR is closed without merge to avoid validation-only repository noise. No mailbox mutation or package release authority was introduced.