### PR TITLE
Validate failure mailbox benchmark v0.4

### DIFF
--- a/validation-markers/failure-benchmark-v0.4.txt
+++ b/validation-markers/failure-benchmark-v0.4.txt
@@ -1,0 +1,2 @@
+Validation marker for failure-mailbox benchmark v0.4 self-coverage gate.
+Underlying source is already on main at 98e22cf40fe528b83445a0d8b7a5c8f875a4efa1.


### PR DESCRIPTION
Validation completed successfully. Test Readiness run 32214501733 / job 95953368889 passed 60/60 deterministic tests. Benchmark schema stegverse.healer.failure-mailbox-benchmark/v0.4 returned PASS. New required checks passed: fixture_intake_complete_coverage, coverage_gap_self_detection, and coverage_monitor_no_authority. Packaging gate now requires coverage_monitor_required=true and positive_coverage_gap_detection_required=true while historical corpus and live incremental benchmarks remain required and package_release_allowed=false. Underlying source was already on main; this marker-only PR is closed without merge.