### PR TITLE
Validate live TVC mailbox observation path

### DIFF
--- a/.github/workflows/failure-mailbox-monitor.yml
+++ b/.github/workflows/failure-mailbox-monitor.yml
@@ -10,6 +10,7 @@ on:
 
 # Healer never receives mailbox credential values. GitHub may physically store
 # the Graph configuration for now, but TV/TVC owns credential processing.
+# Validation branch exercises the same production path; it does not change authority.
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
Validation-only probe consumed. It proved that the direct Healer -> private TVC reusable-workflow call failed before job allocation; no mailbox credential was touched. Superseded by the ARA-carrier + exact TVC processor + credential-neutral Healer reusable diagnostic architecture on main.