### PR TITLE
Add deterministic GitHub Actions cost-pressure analyzer

### DIFF
--- a/app/actions_cost_reducer.py
+++ b/app/actions_cost_reducer.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable
+
+
+CRON_RE = re.compile(r"cron\s*:\s*['\"]?([^'\"\n]+)")
+JOB_RE = re.compile(r"^\s{2}([A-Za-z0-9_.-]+):\s*$")
+MATRIX_INLINE_RE = re.compile(r"\[([^\]]+)\]")
+
+
+@dataclass
+class WorkflowFinding:
+    repository: str
+    workflow: str
+    scheduled: bool
+    cron: list[str]
+    estimated_scheduled_starts_per_day: float
+    estimated_scheduled_starts_per_month: float
+    jobs: int
+    matrix_fanout: int
+    has_push: bool
+    push_path_filtered: bool
+    has_pull_request: bool
+    pull_request_path_filtered: bool
+    has_workflow_dispatch: bool
+    has_concurrency: bool
+    cancel_in_progress: bool
+    artifact_custody: bool
+    checkout_action: bool
+    setup_python_action: bool
+    review_reasons: list[str]
+    remediation_priority: float
+    recommendation: str
+
+
+def _cron_field_values(field: str, minimum: int, maximum: int) -> int | None:
+    field = field.strip()
+    span = maximum - minimum + 1
+    if field == "*":
+        return span
+    if field.startswith("*/"):
+        try:
+            step = int(field[2:])
+        except ValueError:
+            return None
+        if step <= 0:
+            return None
+        return (span + step - 1) // step
+    if "," in field:
+        values = [part.strip() for part in field.split(",") if part.strip()]
+        return len(values) if values else None
+    if re.fullmatch(r"\d+", field):
+        return 1
+    return None
+
+
+def estimate_cron_starts_per_day(expr: str) -> float:
+    """Best-effort lower-complexity estimator for ordinary 5-field GitHub cron."""
+    parts = expr.strip().split()
+    if len(parts) != 5:
+        return 0.0
+    minute, hour, day_of_month, month, day_of_week = parts
+    minute_count = _cron_field_values(minute, 0, 59)
+    hour_count = _cron_field_values(hour, 0, 23)
+    if minute_count is None or hour_count is None:
+        return 0.0
+
+    base = minute_count * hour_count
+    # Monthly/day constraints reduce expected daily starts. We intentionally
+    # avoid claiming precision for complex cron semantics.
+    if day_of_month != "*":
+        if re.fullmatch(r"\d+", day_of_month):
+            base /= 30.0
+        else:
+            return 0.0
+    if month != "*":
+        month_count = _cron_field_values(month, 1, 12)
+        if month_count is None:
+            return 0.0
+        base *= month_count / 12.0
+    if day_of_week != "*":
+        weekday_count = _cron_field_values(day_of_week, 0, 6)
+        if weekday_count is None:
+            return 0.0
+        base *= weekday_count / 7.0
+    return float(base)
+
+
+def _section_has_paths(text: str, trigger: str) -> bool:
+    lines = text.splitlines()
+    trigger_re = re.compile(rf"^\s{{2}}{re.escape(trigger)}\s*:\s*(?:\{{\}})?\s*$")
+    for index, line in enumerate(lines):
+        if not trigger_re.match(line):
+            continue
+        base_indent = len(line) - len(line.lstrip())
+        for child in lines[index + 1 :]:
+            if not child.strip():
+                continue
+            indent = len(child) - len(child.lstrip())
+            if indent <= base_indent:
+                break
+            stripped = child.strip()
+            if stripped.startswith("paths:") or stripped.startswith("paths-ignore:"):
+                return True
+        return False
+    return False
+
+
+def _count_jobs(text: str) -> int:
+    lines = text.splitlines()
+    in_jobs = False
+    count = 0
+    for line in lines:
+        if re.match(r"^jobs:\s*$", line):
+            in_jobs = True
+            continue
+        if in_jobs and line and not line.startswith(" "):
+            break
+        if in_jobs and JOB_RE.match(line):
+            count += 1
+    return max(count, 1 if "runs-on:" in text else 0)
+
+
+def _literal_matrix_fanout(text: str) -> int:
+    lines = text.splitlines()
+    in_matrix = False
+    matrix_indent = None
+    fanout = 1
+    found_dimension = False
+    for line in lines:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        if stripped == "matrix:":
+            in_matrix = True
+            matrix_indent = indent
+            continue
+        if not in_matrix:
+            continue
+        if stripped and indent <= (matrix_indent or 0):
+            in_matrix = False
+            matrix_indent = None
+            continue
+        if ":" not in stripped:
+            continue
+        _, value = stripped.split(":", 1)
+        match = MATRIX_INLINE_RE.search(value)
+        if not match:
+            continue
+        entries = [item.strip() for item in match.group(1).split(",") if item.strip()]
+        if entries:
+            fanout *= len(entries)
+            found_dimension = True
+    return fanout if found_dimension else 1
+
+
+def analyze_workflow(repo_root: Path, workflow_path: Path, policy: dict) -> WorkflowFinding:
+    text = workflow_path.read_text(encoding="utf-8")
+    cron = [match.group(1).strip() for match in CRON_RE.finditer(text)]
+    starts_per_day = sum(estimate_cron_starts_per_day(expr) for expr in cron)
+    starts_per_month = starts_per_day * 31.0
+    has_push = bool(re.search(r"^\s{2}push\s*:", text, re.MULTILINE))
+    has_pull_request = bool(re.search(r"^\s{2}pull_request\s*:", text, re.MULTILINE))
+    has_dispatch = bool(re.search(r"^\s{2}workflow_dispatch\s*:", text, re.MULTILINE))
+    has_concurrency = bool(re.search(r"^concurrency\s*:", text, re.MULTILINE))
+    cancel_in_progress = "cancel-in-progress: true" in text.lower()
+    artifact_custody = "actions/upload-artifact@" in text or "actions/download-artifact@" in text
+    checkout_action = "actions/checkout@" in text
+    setup_python_action = "actions/setup-python@" in text
+    jobs = _count_jobs(text)
+    fanout = _literal_matrix_fanout(text)
+
+    reasons: list[str] = []
+    p = policy["policy"]
+    if starts_per_month >= p["scheduled_workflow_monthly_start_review_threshold"]:
+        reasons.append("HIGH_SCHEDULED_START_PRESSURE")
+    if has_push and p["review_unfiltered_push"] and not _section_has_paths(text, "push"):
+        reasons.append("UNFILTERED_PUSH")
+    if has_pull_request and p["review_unfiltered_pull_request"] and not _section_has_paths(text, "pull_request"):
+        reasons.append("UNFILTERED_PULL_REQUEST")
+    if (has_push or has_pull_request) and p["require_concurrency_for_push_or_pull_request"] and not has_concurrency:
+        reasons.append("MISSING_CONCURRENCY")
+    if has_concurrency and p["require_cancel_in_progress_when_concurrency_present"] and not cancel_in_progress:
+        reasons.append("CONCURRENCY_WITHOUT_CANCEL")
+    if fanout >= p["matrix_fanout_review_threshold"]:
+        reasons.append("MATRIX_FANOUT")
+    if artifact_custody and p["review_artifact_custody_for_validation"]:
+        reasons.append("ARTIFACT_CUSTODY")
+
+    # Weight recurring runner starts most heavily, then fanout and broad event triggers.
+    priority = starts_per_month * max(jobs, 1) * max(fanout, 1)
+    priority += 40.0 * max(fanout - 1, 0)
+    priority += 25.0 * int(has_push and not _section_has_paths(text, "push"))
+    priority += 25.0 * int(has_pull_request and not _section_has_paths(text, "pull_request"))
+    priority += 15.0 * int((has_push or has_pull_request) and not has_concurrency)
+    priority += 10.0 * int(artifact_custody)
+
+    if cron and p["prefer_existing_healer_scheduler_for_recurring_non_authoritative_work"]:
+        recommendation = "REVIEW_FOR_EXISTING_HEALER_SCHEDULER_MIGRATION"
+    elif reasons:
+        recommendation = "CONSOLIDATE_OR_FILTER_HOSTED_VALIDATION"
+    elif has_dispatch and not (cron or has_push or has_pull_request):
+        recommendation = "KEEP_MANUAL_DIAGNOSTIC"
+    else:
+        recommendation = "KEEP_REVIEWED_SURFACE"
+
+    return WorkflowFinding(
+        repository=repo_root.name,
+        workflow=str(workflow_path.relative_to(repo_root)),
+        scheduled=bool(cron),
+        cron=cron,
+        estimated_scheduled_starts_per_day=round(starts_per_day, 6),
+        estimated_scheduled_starts_per_month=round(starts_per_month, 3),
+        jobs=jobs,
+        matrix_fanout=fanout,
+        has_push=has_push,
+        push_path_filtered=_section_has_paths(text, "push"),
+        has_pull_request=has_pull_request,
+        pull_request_path_filtered=_section_has_paths(text, "pull_request"),
+        has_workflow_dispatch=has_dispatch,
+        has_concurrency=has_concurrency,
+        cancel_in_progress=cancel_in_progress,
+        artifact_custody=artifact_custody,
+        checkout_action=checkout_action,
+        setup_python_action=setup_python_action,
+        review_reasons=reasons,
+        remediation_priority=round(priority, 3),
+        recommendation=recommendation,
+    )
+
+
+def iter_workflows(repo_root: Path) -> Iterable[Path]:
+    workflow_dir = repo_root / ".github" / "workflows"
+    if not workflow_dir.is_dir():
+        return []
+    return sorted([*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")])
+
+
+def load_roots(cli_roots: list[str]) -> list[Path]:
+    if cli_roots:
+        return [Path(root).resolve() for root in cli_roots]
+    raw = os.environ.get("STEGVERSE_REPO_ROOTS_JSON", "")
+    if not raw:
+        return []
+    value = json.loads(raw)
+    if isinstance(value, dict):
+        return [Path(path).resolve() for path in value.values()]
+    if isinstance(value, list):
+        return [Path(path).resolve() for path in value]
+    raise ValueError("STEGVERSE_REPO_ROOTS_JSON must be an object or list")
+
+
+def build_report(roots: list[Path], policy: dict) -> dict:
+    findings: list[WorkflowFinding] = []
+    missing_roots: list[str] = []
+    for root in roots:
+        if not root.is_dir():
+            missing_roots.append(str(root))
+            continue
+        for workflow in iter_workflows(root):
+            findings.append(analyze_workflow(root, workflow, policy))
+    findings.sort(key=lambda row: (-row.remediation_priority, row.repository, row.workflow))
+    scheduled_monthly = sum(row.estimated_scheduled_starts_per_month * max(row.jobs, 1) * max(row.matrix_fanout, 1) for row in findings)
+    report = {
+        "schema": "stegverse.github-actions-cost-analysis.v1",
+        "state": "PASS" if roots and not missing_roots else "BLOCKED",
+        "credential_authority": "TV/TVC",
+        "github_token_required": False,
+        "network_required": False,
+        "authority_effect": "NONE",
+        "repository_roots_requested": len(roots),
+        "missing_repository_roots": missing_roots,
+        "workflow_count": len(findings),
+        "scheduled_workflow_count": sum(1 for row in findings if row.scheduled),
+        "review_candidate_count": sum(1 for row in findings if row.review_reasons),
+        "estimated_scheduled_job_starts_per_month": round(scheduled_monthly, 3),
+        "ranked_findings": [asdict(row) for row in findings],
+    }
+    return report
+
+
+def enforce(report: dict, policy: dict) -> list[str]:
+    failures: list[str] = []
+    threshold = policy["policy"]["scheduled_workflow_monthly_start_enforce_threshold"]
+    for row in report["ranked_findings"]:
+        starts = row["estimated_scheduled_starts_per_month"] * max(row["jobs"], 1) * max(row["matrix_fanout"], 1)
+        if starts >= threshold:
+            failures.append(f"{row['repository']}:{row['workflow']}: scheduled starts {starts:.1f}/month >= {threshold}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deterministic GitHub Actions cost-pressure analyzer")
+    parser.add_argument("roots", nargs="*", help="Repository roots; defaults to STEGVERSE_REPO_ROOTS_JSON")
+    parser.add_argument("--policy", default="data/actions_cost_policy.json")
+    parser.add_argument("--output", default="actions-cost-analysis.report.json")
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+
+    policy = json.loads(Path(args.policy).read_text(encoding="utf-8"))
+    roots = load_roots(args.roots)
+    report = build_report(roots, policy)
+    failures = enforce(report, policy) if args.enforce else []
+    report["enforcement_failures"] = failures
+    if failures:
+        report["state"] = "FAIL_CLOSED"
+    Path(args.output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "state": report["state"],
+        "workflow_count": report["workflow_count"],
+        "scheduled_workflow_count": report["scheduled_workflow_count"],
+        "review_candidate_count": report["review_candidate_count"],
+        "estimated_scheduled_job_starts_per_month": report["estimated_scheduled_job_starts_per_month"],
+        "output": args.output,
+    }, sort_keys=True))
+    return 1 if report["state"] in {"BLOCKED", "FAIL_CLOSED"} else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/audit_schedules.py
+++ b/app/audit_schedules.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from app.actions_cost_reducer import build_report
+
 VALID_STATES = {"COMPLETE", "BLOCKED", "RETRY", "REVIEW_REQUIRED", "FAILED"}
 FORBIDDEN_CREDENTIALS = ("HEALER_GH_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "HEALER_PAT", "GH_STEGVERSE_AI_TOKEN")
 
@@ -92,7 +94,45 @@ def stable_projection(receipt: dict[str, Any]) -> dict[str, Any]:
         "allowed_scheduler_repository": receipt["allowed_scheduler_repository"],
         "repositories": receipt["repositories"],
         "summary": receipt["summary"],
+        "cost_analysis": receipt.get("cost_analysis"),
         "next_executable_task": receipt["next_executable_task"],
+    }
+
+
+def load_cost_policy() -> dict[str, Any]:
+    policy_path = Path(os.environ.get("ACTIONS_COST_POLICY", "data/actions_cost_policy.json"))
+    value = json.loads(policy_path.read_text(encoding="utf-8"))
+    if value.get("schema") != "stegverse.github-actions-cost-policy.v1":
+        raise ValueError("invalid Actions cost policy schema")
+    return value
+
+
+def compact_cost_analysis(report: dict[str, Any]) -> dict[str, Any]:
+    ranked = report.get("ranked_findings", [])
+    top = []
+    for row in ranked[:20]:
+        top.append({
+            "repository": row.get("repository"),
+            "workflow": row.get("workflow"),
+            "estimated_scheduled_starts_per_month": row.get("estimated_scheduled_starts_per_month"),
+            "jobs": row.get("jobs"),
+            "matrix_fanout": row.get("matrix_fanout"),
+            "review_reasons": row.get("review_reasons"),
+            "remediation_priority": row.get("remediation_priority"),
+            "recommendation": row.get("recommendation"),
+        })
+    return {
+        "schema": report.get("schema"),
+        "state": report.get("state"),
+        "credential_authority": report.get("credential_authority"),
+        "github_token_required": report.get("github_token_required"),
+        "network_required": report.get("network_required"),
+        "authority_effect": report.get("authority_effect"),
+        "workflow_count": report.get("workflow_count"),
+        "scheduled_workflow_count": report.get("scheduled_workflow_count"),
+        "review_candidate_count": report.get("review_candidate_count"),
+        "estimated_scheduled_job_starts_per_month": report.get("estimated_scheduled_job_starts_per_month"),
+        "top_remediation_candidates": top,
     }
 
 
@@ -109,6 +149,8 @@ def main() -> int:
     try:
         targets = load_targets(targets_path)
         roots = load_roots()
+        cost_policy = load_cost_policy()
+        cost_report = build_report(list(roots.values()), cost_policy)
     except Exception as exc:
         print(f"Invalid sovereign audit configuration: {exc}", file=sys.stderr)
         return 2
@@ -121,16 +163,16 @@ def main() -> int:
 
     if failed or violations:
         state = "FAILED"
-        next_task = "Remove every repository-local schedule trigger and preserve cadence in the resident heartbeat/Healer target registry."
+        next_task = "Remove every repository-local schedule trigger, preserve cadence in the resident heartbeat/Healer target registry, and consume the ranked cost-analysis candidates in descending priority."
     elif blocked:
         state = "BLOCKED"
-        next_task = "Materialize every managed repository on the sovereign carrier and rerun the local schedule audit."
+        next_task = "Materialize every managed repository on the sovereign carrier and rerun the local schedule and cost-pressure audit."
     else:
         state = "COMPLETE"
-        next_task = "Retain heartbeat-owned cadence and continue local schedule auditing."
+        next_task = "Retain heartbeat-owned cadence and migrate the highest-value non-colliding cost-analysis candidate without capability loss."
 
     receipt: dict[str, Any] = {
-        "schema": "stegverse.healer.quiet-enforcer-receipt.v2",
+        "schema": "stegverse.healer.quiet-enforcer-receipt.v3",
         "state": state,
         "manager": "single_stegverse_heartbeat",
         "allowed_scheduler_repository": None,
@@ -146,7 +188,10 @@ def main() -> int:
             "retry_count": 0,
             "review_required_count": 0,
             "failed_count": failed,
+            "cost_review_candidate_count": cost_report.get("review_candidate_count", 0),
+            "estimated_scheduled_job_starts_per_month": cost_report.get("estimated_scheduled_job_starts_per_month", 0),
         },
+        "cost_analysis": compact_cost_analysis(cost_report),
         "next_executable_task": next_task,
     }
     if receipt["state"] not in VALID_STATES:

--- a/data/actions_cost_policy.json
+++ b/data/actions_cost_policy.json
@@ -1,0 +1,21 @@
+{
+  "schema": "stegverse.github-actions-cost-policy.v1",
+  "credential_authority": "TV/TVC",
+  "github_actions_production_role": "NONE",
+  "policy": {
+    "scheduled_workflow_monthly_start_review_threshold": 120,
+    "scheduled_workflow_monthly_start_enforce_threshold": 744,
+    "matrix_fanout_review_threshold": 4,
+    "require_concurrency_for_push_or_pull_request": true,
+    "require_cancel_in_progress_when_concurrency_present": true,
+    "review_unfiltered_push": true,
+    "review_unfiltered_pull_request": true,
+    "review_artifact_custody_for_validation": true,
+    "prefer_existing_healer_scheduler_for_recurring_non_authoritative_work": true,
+    "automatic_workflow_mutation": false,
+    "automatic_schedule_mutation": false,
+    "github_token_workaround_allowed": false,
+    "render_workaround_allowed": false
+  },
+  "authority_effect": "NONE"
+}

--- a/docs/GITHUB_ACTIONS_COST_REDUCTION_MIRROR_HANDOFF.md
+++ b/docs/GITHUB_ACTIONS_COST_REDUCTION_MIRROR_HANDOFF.md
@@ -1,0 +1,83 @@
+# GitHub Actions Cost Reduction Mirror Handoff
+
+Updated: 2026-08-20T07:35:00-05:00
+
+## Goal
+
+Reduce StegVerse GitHub-hosted workflow spend without reducing validation capability or moving runtime, credential, publication, custody, wallet, or execution authority into GitHub Actions.
+
+```text
+goal_id: HEALER-GITHUB-ACTIONS-COST-REDUCTION-001
+repository: StegVerse-Labs/StegVerse-Healer
+branch: feat/actions-cost-reduction-enforcer-20260820
+credential_authority: TV/TVC
+non_tv_tvc_secret_or_token_allowed: false
+github_actions_production_role: NONE
+scheduler_owner: SHWP-HEALER-SOVEREIGN-SCHEDULER-001
+state: SOURCE_IMPLEMENTATION_IN_PROGRESS
+```
+
+This work reuses the existing sovereign Healer scheduler. It must not create a second scheduler or heartbeat.
+
+## Existing evidence and integration boundary
+
+Site already has an active cost-containment program under `StegVerse-Labs/Site#268` and `docs/ACTIONS_COST_CONTAINMENT_MIRROR_HANDOFF.md`. That program reduced the Site workflow census from 131 audit-start surfaces to 98 current-main surfaces and has already retired standalone hourly GitHub-hosted loops by moving recurring observation to the existing Healer scheduler.
+
+TV has also removed a local daily schedule in favor of the existing Healer scheduler. This Healer goal does not duplicate those migrations. It supplies the missing cross-repository deterministic cost-analysis layer used to choose the next highest-value migration.
+
+## Installed surfaces
+
+```text
+app/actions_cost_reducer.py
+data/actions_cost_policy.json
+tests/test_actions_cost_reducer.py
+docs/GITHUB_ACTIONS_COST_REDUCTION_MIRROR_HANDOFF.md
+```
+
+## Required behavior
+
+The analyzer must work without GitHub credentials, network access, provider secrets, or hosted Actions. Given one or more locally materialized repository roots, it must:
+
+1. inventory `.github/workflows/*.yml` and `*.yaml`;
+2. identify scheduled workflows and estimate minimum scheduled starts per day/month for common cron forms;
+3. count literal job and matrix fanout surfaces;
+4. identify missing `concurrency`/`cancel-in-progress` protection;
+5. identify unfiltered `push`/`pull_request` triggers;
+6. identify artifact upload/download custody surfaces;
+7. distinguish manual-only workflows from recurring/push/PR workflows;
+8. rank remediation candidates by avoidable hosted-run pressure;
+9. recommend reuse of the sovereign Healer scheduler for recurring validation/observation that has no GitHub-hosted authority requirement;
+10. emit deterministic JSON suitable for replay and later repository-specific migration receipts.
+
+The analyzer is advisory by default. `--enforce` may fail only on explicit policy violations. It must never delete workflows or mutate another repository automatically.
+
+## Cost-control principles
+
+```text
+capability_preservation_required: true
+cost_reduction_without_capability_loss: preferred
+cost_reduction_with_capability_gain: strongest preference
+hosted_schedule_for_non_authoritative_observation: migration_candidate
+manual_only_diagnostic: low recurring cost
+push_or_pr_without_path_filter: review_candidate
+missing_concurrency_cancel: review_candidate
+literal_matrix_fanout: cost_multiplier
+artifact_custody_for_ephemeral_validation: review_candidate
+github_token_or_secret_workaround: prohibited
+render_workaround: prohibited
+```
+
+## Activation boundary
+
+Source implementation and deterministic tests do not prove ecosystem savings. Goal activation requires at least one analyzer-produced ranked report over current locally materialized StegVerse repositories, followed by one evidence-preserving migration that reduces expected GitHub-hosted runner starts without reducing capability.
+
+## Next actions
+
+1. Install analyzer, policy, and deterministic tests on this branch.
+2. Validate locally or through a credential-clean source-validation carrier when available.
+3. Run against locally materialized StegVerse repository roots through the existing sovereign scheduler/runtime environment.
+4. Persist the ranked remediation report.
+5. Select the highest-value non-colliding candidate and migrate it to an existing canonical validation surface or the existing Healer scheduler.
+6. Measure before/after runner-start pressure and preserve capability evidence.
+
+No billing-limit increase, GitHub token installation, Render deployment, or authority expansion is authorized by this handoff.

--- a/docs/GITHUB_ACTIONS_COST_REDUCTION_MIRROR_HANDOFF.md
+++ b/docs/GITHUB_ACTIONS_COST_REDUCTION_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # GitHub Actions Cost Reduction Mirror Handoff
 
-Updated: 2026-08-20T07:35:00-05:00
+Updated: 2026-08-20T07:44:00-05:00
 
 ## Goal
 
@@ -10,46 +10,53 @@ Reduce StegVerse GitHub-hosted workflow spend without reducing validation capabi
 goal_id: HEALER-GITHUB-ACTIONS-COST-REDUCTION-001
 repository: StegVerse-Labs/StegVerse-Healer
 branch: feat/actions-cost-reduction-enforcer-20260820
+pull_request: 32
 credential_authority: TV/TVC
 non_tv_tvc_secret_or_token_allowed: false
 github_actions_production_role: NONE
 scheduler_owner: SHWP-HEALER-SOVEREIGN-SCHEDULER-001
-state: SOURCE_IMPLEMENTATION_IN_PROGRESS
+state: SOURCE_IMPLEMENTED_QUIET_ENFORCER_INTEGRATED_VALIDATION_PENDING
 ```
 
-This work reuses the existing sovereign Healer scheduler. It must not create a second scheduler or heartbeat.
+This work reuses the existing sovereign Healer scheduler and Quiet Enforcer. It creates no second scheduler or heartbeat.
 
 ## Existing evidence and integration boundary
 
 Site already has an active cost-containment program under `StegVerse-Labs/Site#268` and `docs/ACTIONS_COST_CONTAINMENT_MIRROR_HANDOFF.md`. That program reduced the Site workflow census from 131 audit-start surfaces to 98 current-main surfaces and has already retired standalone hourly GitHub-hosted loops by moving recurring observation to the existing Healer scheduler.
 
-TV has also removed a local daily schedule in favor of the existing Healer scheduler. This Healer goal does not duplicate those migrations. It supplies the missing cross-repository deterministic cost-analysis layer used to choose the next highest-value migration.
+TV has also removed a local daily schedule in favor of the existing Healer scheduler. This Healer goal does not duplicate those migrations. It supplies the cross-repository deterministic cost-analysis layer used to choose the next highest-value migration.
 
 ## Installed surfaces
 
 ```text
-app/actions_cost_reducer.py
-data/actions_cost_policy.json
-tests/test_actions_cost_reducer.py
 docs/GITHUB_ACTIONS_COST_REDUCTION_MIRROR_HANDOFF.md
+data/actions_cost_policy.json
+app/actions_cost_reducer.py
+app/audit_schedules.py integration
+tests/test_actions_cost_reducer.py
+tests/test_quiet_enforcer_cost_integration.py
 ```
 
-## Required behavior
+Source commits on the branch:
 
-The analyzer must work without GitHub credentials, network access, provider secrets, or hosted Actions. Given one or more locally materialized repository roots, it must:
+```text
+handoff creation: 9edcfb91041bb95feb56ff6c09bde16f9f465dc1
+policy: b458fd2fa01a35bcf40fd220b276308345f82720
+analyzer: 32646bff235872c0791f864666310c2cb6999bf6
+analyzer tests: 5fd8250b811f0d513a5755bf2ed5daa3696b136d
+Quiet Enforcer integration: 9fadbc0b49996281807a8438eef78a8491c27d5f
+integration tests: 10e6a1306217e828e4880fd910708dc814b8a4c5
+```
 
-1. inventory `.github/workflows/*.yml` and `*.yaml`;
-2. identify scheduled workflows and estimate minimum scheduled starts per day/month for common cron forms;
-3. count literal job and matrix fanout surfaces;
-4. identify missing `concurrency`/`cancel-in-progress` protection;
-5. identify unfiltered `push`/`pull_request` triggers;
-6. identify artifact upload/download custody surfaces;
-7. distinguish manual-only workflows from recurring/push/PR workflows;
-8. rank remediation candidates by avoidable hosted-run pressure;
-9. recommend reuse of the sovereign Healer scheduler for recurring validation/observation that has no GitHub-hosted authority requirement;
-10. emit deterministic JSON suitable for replay and later repository-specific migration receipts.
+## Installed behavior
 
-The analyzer is advisory by default. `--enforce` may fail only on explicit policy violations. It must never delete workflows or mutate another repository automatically.
+The analyzer works from locally materialized repository roots and requires no GitHub credential, network call, provider secret, or hosted Actions execution. It inventories `.github/workflows/*.yml` and `*.yaml`, estimates common cron start pressure, counts jobs and literal matrix fanout, detects broad push/PR triggers, missing concurrency cancellation, artifact custody, manual-only diagnostics, and ranks remediation candidates.
+
+Policy is explicit and machine-readable at `data/actions_cost_policy.json`. The analyzer is advisory by default and may fail closed under `--enforce` only at the configured high scheduled-start threshold. It never mutates another repository automatically.
+
+The existing `app/audit_schedules.py` Quiet Enforcer now embeds a compact cost-analysis projection in `stegverse.healer.quiet-enforcer-receipt.v3`. This means the already-established `quiet_enforcer.yml` sovereign scheduler target becomes the execution carrier for ranked cost-pressure analysis; no new scheduled GitHub workflow and no new Healer target are required.
+
+The Quiet Enforcer retains its stronger invariant: repository-local `schedule:` triggers in managed repositories remain violations. The added cost analysis additionally ranks non-scheduled cost pressure such as unfiltered push/PR triggers, missing cancellation, matrices, and artifact custody.
 
 ## Cost-control principles
 
@@ -65,19 +72,41 @@ literal_matrix_fanout: cost_multiplier
 artifact_custody_for_ephemeral_validation: review_candidate
 github_token_or_secret_workaround: prohibited
 render_workaround: prohibited
+automatic_cross_repo_mutation: prohibited
 ```
+
+## Deterministic test coverage installed
+
+`tests/test_actions_cost_reducer.py` covers:
+
+- hourly, six-hourly, daily, and weekday cron estimation;
+- hourly migration ranking;
+- path-filtered push/PR with concurrency cancellation;
+- matrix fanout and artifact-custody detection;
+- manual-only low-recurring-cost classification;
+- report ranking and enforcement threshold behavior;
+- fail-closed missing-root behavior.
+
+`tests/test_quiet_enforcer_cost_integration.py` covers:
+
+- Quiet Enforcer v3 embedding of ranked cost analysis while preserving a COMPLETE schedule-audit result;
+- detection/ranking of a broad unfiltered push surface;
+- preservation of the existing fail-closed repository-local schedule invariant;
+- expected 744 monthly starts for an hourly single-job schedule.
+
+These tests are installed but no hosted workflow result is treated as source or runtime proof while GitHub-hosted execution is admission/billing constrained.
 
 ## Activation boundary
 
-Source implementation and deterministic tests do not prove ecosystem savings. Goal activation requires at least one analyzer-produced ranked report over current locally materialized StegVerse repositories, followed by one evidence-preserving migration that reduces expected GitHub-hosted runner starts without reducing capability.
+Source implementation and test installation do not prove ecosystem savings. Goal activation requires the existing sovereign Quiet Enforcer to execute against current locally materialized StegVerse repositories, persist a ranked cost-analysis receipt, and then at least one evidence-preserving migration must reduce expected GitHub-hosted runner starts without reducing capability.
 
-## Next actions
+## Exact next actions
 
-1. Install analyzer, policy, and deterministic tests on this branch.
-2. Validate locally or through a credential-clean source-validation carrier when available.
-3. Run against locally materialized StegVerse repository roots through the existing sovereign scheduler/runtime environment.
-4. Persist the ranked remediation report.
-5. Select the highest-value non-colliding candidate and migrate it to an existing canonical validation surface or the existing Healer scheduler.
-6. Measure before/after runner-start pressure and preserve capability evidence.
+1. Validate PR #32 through the strongest credential-clean available source path.
+2. Merge only after source validation is satisfied and the branch remains current.
+3. Allow the existing `quiet_enforcer.yml` Healer target to produce the first v3 receipt on the sovereign scheduler.
+4. Select the highest-ranked candidate that is not actively claimed by another workstream.
+5. Migrate that candidate to an existing canonical validation surface or the existing Healer scheduler while preserving semantics.
+6. Record before/after runner-start pressure and continue iteratively until recurring hosted validation is exceptional rather than default.
 
-No billing-limit increase, GitHub token installation, Render deployment, or authority expansion is authorized by this handoff.
+No billing-limit increase, GitHub token installation, Render deployment, automatic purchase, or authority expansion is authorized by this handoff.

--- a/tests/test_actions_cost_reducer.py
+++ b/tests/test_actions_cost_reducer.py
@@ -1,4 +1,6 @@
 import json
+import tempfile
+import unittest
 from pathlib import Path
 
 from app.actions_cost_reducer import (
@@ -32,93 +34,90 @@ def write_workflow(root: Path, name: str, body: str) -> Path:
     return path
 
 
-def test_cron_estimator_common_forms():
-    assert estimate_cron_starts_per_day("23 * * * *") == 24.0
-    assert estimate_cron_starts_per_day("0 */6 * * *") == 4.0
-    assert estimate_cron_starts_per_day("0 6 * * *") == 1.0
-    assert round(estimate_cron_starts_per_day("0 6 * * 1"), 6) == round(1 / 7, 6)
+class ActionsCostReducerTests(unittest.TestCase):
+    def test_cron_estimator_common_forms(self):
+        self.assertEqual(estimate_cron_starts_per_day("23 * * * *"), 24.0)
+        self.assertEqual(estimate_cron_starts_per_day("0 */6 * * *"), 4.0)
+        self.assertEqual(estimate_cron_starts_per_day("0 6 * * *"), 1.0)
+        self.assertEqual(round(estimate_cron_starts_per_day("0 6 * * 1"), 6), round(1 / 7, 6))
+
+    def test_hourly_workflow_is_ranked_for_healer_migration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "Site"
+            workflow = write_workflow(
+                root,
+                "hourly.yml",
+                """name: Hourly\non:\n  schedule:\n    - cron: '23 * * * *'\n  workflow_dispatch: {}\njobs:\n  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n""",
+            )
+            finding = analyze_workflow(root, workflow, POLICY)
+            self.assertTrue(finding.scheduled)
+            self.assertEqual(finding.estimated_scheduled_starts_per_month, 744.0)
+            self.assertIn("HIGH_SCHEDULED_START_PRESSURE", finding.review_reasons)
+            self.assertEqual(finding.recommendation, "REVIEW_FOR_EXISTING_HEALER_SCHEDULER_MIGRATION")
+
+    def test_path_filtered_concurrent_validation_avoids_broad_trigger_findings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "Repo"
+            workflow = write_workflow(
+                root,
+                "validate.yml",
+                """name: Validate\non:\n  push:\n    paths:\n      - 'src/**'\n  pull_request:\n    paths:\n      - 'src/**'\nconcurrency:\n  group: validate-${{ github.ref }}\n  cancel-in-progress: true\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: python -m pytest\n""",
+            )
+            finding = analyze_workflow(root, workflow, POLICY)
+            self.assertTrue(finding.push_path_filtered)
+            self.assertTrue(finding.pull_request_path_filtered)
+            self.assertTrue(finding.has_concurrency)
+            self.assertTrue(finding.cancel_in_progress)
+            self.assertNotIn("UNFILTERED_PUSH", finding.review_reasons)
+            self.assertNotIn("UNFILTERED_PULL_REQUEST", finding.review_reasons)
+            self.assertNotIn("MISSING_CONCURRENCY", finding.review_reasons)
+
+    def test_matrix_and_artifact_pressure_are_detected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "Repo"
+            workflow = write_workflow(
+                root,
+                "matrix.yml",
+                """name: Matrix\non:\n  push: {}\njobs:\n  test:\n    strategy:\n      matrix:\n        python: [3.10, 3.11]\n        os: [ubuntu, windows]\n    runs-on: ${{ matrix.os }}\n    steps:\n      - uses: actions/upload-artifact@v4\n""",
+            )
+            finding = analyze_workflow(root, workflow, POLICY)
+            self.assertEqual(finding.matrix_fanout, 4)
+            self.assertTrue(finding.artifact_custody)
+            self.assertIn("MATRIX_FANOUT", finding.review_reasons)
+            self.assertIn("ARTIFACT_CUSTODY", finding.review_reasons)
+            self.assertIn("UNFILTERED_PUSH", finding.review_reasons)
+
+    def test_manual_only_diagnostic_is_low_recurring_cost(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "Repo"
+            workflow = write_workflow(
+                root,
+                "manual.yml",
+                """name: Manual\non:\n  workflow_dispatch: {}\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n""",
+            )
+            finding = analyze_workflow(root, workflow, POLICY)
+            self.assertEqual(finding.estimated_scheduled_starts_per_month, 0)
+            self.assertEqual(finding.recommendation, "KEEP_MANUAL_DIAGNOSTIC")
+
+    def test_report_ranks_hourly_before_manual_and_enforcement_fails_hourly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "Repo"
+            write_workflow(root, "hourly.yml", """name: Hourly\non:\n  schedule:\n    - cron: '0 * * * *'\njobs:\n  one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo one\n""")
+            write_workflow(root, "manual.yml", """name: Manual\non:\n  workflow_dispatch: {}\njobs:\n  one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo one\n""")
+            report = build_report([root], POLICY)
+            self.assertEqual(report["state"], "PASS")
+            self.assertEqual(report["workflow_count"], 2)
+            self.assertTrue(report["ranked_findings"][0]["workflow"].endswith("hourly.yml"))
+            failures = enforce(report, POLICY)
+            self.assertEqual(len(failures), 1)
+            self.assertIn("hourly.yml", failures[0])
+
+    def test_missing_root_blocks_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = build_report([Path(tmp) / "missing"], POLICY)
+            self.assertEqual(report["state"], "BLOCKED")
+            self.assertTrue(report["missing_repository_roots"])
 
 
-def test_hourly_workflow_is_ranked_for_healer_migration(tmp_path):
-    root = tmp_path / "Site"
-    workflow = write_workflow(
-        root,
-        "hourly.yml",
-        """name: Hourly\non:\n  schedule:\n    - cron: '23 * * * *'\n  workflow_dispatch: {}\njobs:\n  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n""",
-    )
-    finding = analyze_workflow(root, workflow, POLICY)
-    assert finding.scheduled is True
-    assert finding.estimated_scheduled_starts_per_month == 744.0
-    assert "HIGH_SCHEDULED_START_PRESSURE" in finding.review_reasons
-    assert finding.recommendation == "REVIEW_FOR_EXISTING_HEALER_SCHEDULER_MIGRATION"
-
-
-def test_path_filtered_concurrent_validation_avoids_broad_trigger_findings(tmp_path):
-    root = tmp_path / "Repo"
-    workflow = write_workflow(
-        root,
-        "validate.yml",
-        """name: Validate\non:\n  push:\n    paths:\n      - 'src/**'\n  pull_request:\n    paths:\n      - 'src/**'\nconcurrency:\n  group: validate-${{ github.ref }}\n  cancel-in-progress: true\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: python -m pytest\n""",
-    )
-    finding = analyze_workflow(root, workflow, POLICY)
-    assert finding.push_path_filtered is True
-    assert finding.pull_request_path_filtered is True
-    assert finding.has_concurrency is True
-    assert finding.cancel_in_progress is True
-    assert "UNFILTERED_PUSH" not in finding.review_reasons
-    assert "UNFILTERED_PULL_REQUEST" not in finding.review_reasons
-    assert "MISSING_CONCURRENCY" not in finding.review_reasons
-
-
-def test_matrix_and_artifact_pressure_are_detected(tmp_path):
-    root = tmp_path / "Repo"
-    workflow = write_workflow(
-        root,
-        "matrix.yml",
-        """name: Matrix\non:\n  push: {}\njobs:\n  test:\n    strategy:\n      matrix:\n        python: [3.10, 3.11]\n        os: [ubuntu, windows]\n    runs-on: ${{ matrix.os }}\n    steps:\n      - uses: actions/upload-artifact@v4\n""",
-    )
-    finding = analyze_workflow(root, workflow, POLICY)
-    assert finding.matrix_fanout == 4
-    assert finding.artifact_custody is True
-    assert "MATRIX_FANOUT" in finding.review_reasons
-    assert "ARTIFACT_CUSTODY" in finding.review_reasons
-    assert "UNFILTERED_PUSH" in finding.review_reasons
-
-
-def test_manual_only_diagnostic_is_low_recurring_cost(tmp_path):
-    root = tmp_path / "Repo"
-    workflow = write_workflow(
-        root,
-        "manual.yml",
-        """name: Manual\non:\n  workflow_dispatch: {}\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n""",
-    )
-    finding = analyze_workflow(root, workflow, POLICY)
-    assert finding.estimated_scheduled_starts_per_month == 0
-    assert finding.recommendation == "KEEP_MANUAL_DIAGNOSTIC"
-
-
-def test_report_ranks_hourly_before_manual_and_enforcement_fails_hourly(tmp_path):
-    root = tmp_path / "Repo"
-    write_workflow(
-        root,
-        "hourly.yml",
-        """name: Hourly\non:\n  schedule:\n    - cron: '0 * * * *'\njobs:\n  one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo one\n""",
-    )
-    write_workflow(
-        root,
-        "manual.yml",
-        """name: Manual\non:\n  workflow_dispatch: {}\njobs:\n  one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo one\n""",
-    )
-    report = build_report([root], POLICY)
-    assert report["state"] == "PASS"
-    assert report["workflow_count"] == 2
-    assert report["ranked_findings"][0]["workflow"].endswith("hourly.yml")
-    failures = enforce(report, POLICY)
-    assert len(failures) == 1
-    assert "hourly.yml" in failures[0]
-
-
-def test_missing_root_blocks_report(tmp_path):
-    report = build_report([tmp_path / "missing"], POLICY)
-    assert report["state"] == "BLOCKED"
-    assert report["missing_repository_roots"]
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_actions_cost_reducer.py
+++ b/tests/test_actions_cost_reducer.py
@@ -1,0 +1,124 @@
+import json
+from pathlib import Path
+
+from app.actions_cost_reducer import (
+    analyze_workflow,
+    build_report,
+    enforce,
+    estimate_cron_starts_per_day,
+)
+
+
+POLICY = {
+    "schema": "stegverse.github-actions-cost-policy.v1",
+    "policy": {
+        "scheduled_workflow_monthly_start_review_threshold": 120,
+        "scheduled_workflow_monthly_start_enforce_threshold": 744,
+        "matrix_fanout_review_threshold": 4,
+        "require_concurrency_for_push_or_pull_request": True,
+        "require_cancel_in_progress_when_concurrency_present": True,
+        "review_unfiltered_push": True,
+        "review_unfiltered_pull_request": True,
+        "review_artifact_custody_for_validation": True,
+        "prefer_existing_healer_scheduler_for_recurring_non_authoritative_work": True,
+    },
+}
+
+
+def write_workflow(root: Path, name: str, body: str) -> Path:
+    path = root / ".github" / "workflows" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_cron_estimator_common_forms():
+    assert estimate_cron_starts_per_day("23 * * * *") == 24.0
+    assert estimate_cron_starts_per_day("0 */6 * * *") == 4.0
+    assert estimate_cron_starts_per_day("0 6 * * *") == 1.0
+    assert round(estimate_cron_starts_per_day("0 6 * * 1"), 6) == round(1 / 7, 6)
+
+
+def test_hourly_workflow_is_ranked_for_healer_migration(tmp_path):
+    root = tmp_path / "Site"
+    workflow = write_workflow(
+        root,
+        "hourly.yml",
+        """name: Hourly\non:\n  schedule:\n    - cron: '23 * * * *'\n  workflow_dispatch: {}\njobs:\n  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n""",
+    )
+    finding = analyze_workflow(root, workflow, POLICY)
+    assert finding.scheduled is True
+    assert finding.estimated_scheduled_starts_per_month == 744.0
+    assert "HIGH_SCHEDULED_START_PRESSURE" in finding.review_reasons
+    assert finding.recommendation == "REVIEW_FOR_EXISTING_HEALER_SCHEDULER_MIGRATION"
+
+
+def test_path_filtered_concurrent_validation_avoids_broad_trigger_findings(tmp_path):
+    root = tmp_path / "Repo"
+    workflow = write_workflow(
+        root,
+        "validate.yml",
+        """name: Validate\non:\n  push:\n    paths:\n      - 'src/**'\n  pull_request:\n    paths:\n      - 'src/**'\nconcurrency:\n  group: validate-${{ github.ref }}\n  cancel-in-progress: true\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: python -m pytest\n""",
+    )
+    finding = analyze_workflow(root, workflow, POLICY)
+    assert finding.push_path_filtered is True
+    assert finding.pull_request_path_filtered is True
+    assert finding.has_concurrency is True
+    assert finding.cancel_in_progress is True
+    assert "UNFILTERED_PUSH" not in finding.review_reasons
+    assert "UNFILTERED_PULL_REQUEST" not in finding.review_reasons
+    assert "MISSING_CONCURRENCY" not in finding.review_reasons
+
+
+def test_matrix_and_artifact_pressure_are_detected(tmp_path):
+    root = tmp_path / "Repo"
+    workflow = write_workflow(
+        root,
+        "matrix.yml",
+        """name: Matrix\non:\n  push: {}\njobs:\n  test:\n    strategy:\n      matrix:\n        python: [3.10, 3.11]\n        os: [ubuntu, windows]\n    runs-on: ${{ matrix.os }}\n    steps:\n      - uses: actions/upload-artifact@v4\n""",
+    )
+    finding = analyze_workflow(root, workflow, POLICY)
+    assert finding.matrix_fanout == 4
+    assert finding.artifact_custody is True
+    assert "MATRIX_FANOUT" in finding.review_reasons
+    assert "ARTIFACT_CUSTODY" in finding.review_reasons
+    assert "UNFILTERED_PUSH" in finding.review_reasons
+
+
+def test_manual_only_diagnostic_is_low_recurring_cost(tmp_path):
+    root = tmp_path / "Repo"
+    workflow = write_workflow(
+        root,
+        "manual.yml",
+        """name: Manual\non:\n  workflow_dispatch: {}\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n""",
+    )
+    finding = analyze_workflow(root, workflow, POLICY)
+    assert finding.estimated_scheduled_starts_per_month == 0
+    assert finding.recommendation == "KEEP_MANUAL_DIAGNOSTIC"
+
+
+def test_report_ranks_hourly_before_manual_and_enforcement_fails_hourly(tmp_path):
+    root = tmp_path / "Repo"
+    write_workflow(
+        root,
+        "hourly.yml",
+        """name: Hourly\non:\n  schedule:\n    - cron: '0 * * * *'\njobs:\n  one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo one\n""",
+    )
+    write_workflow(
+        root,
+        "manual.yml",
+        """name: Manual\non:\n  workflow_dispatch: {}\njobs:\n  one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo one\n""",
+    )
+    report = build_report([root], POLICY)
+    assert report["state"] == "PASS"
+    assert report["workflow_count"] == 2
+    assert report["ranked_findings"][0]["workflow"].endswith("hourly.yml")
+    failures = enforce(report, POLICY)
+    assert len(failures) == 1
+    assert "hourly.yml" in failures[0]
+
+
+def test_missing_root_blocks_report(tmp_path):
+    report = build_report([tmp_path / "missing"], POLICY)
+    assert report["state"] == "BLOCKED"
+    assert report["missing_repository_roots"]

--- a/tests/test_quiet_enforcer_cost_integration.py
+++ b/tests/test_quiet_enforcer_cost_integration.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+from app import audit_schedules
+
+
+def test_quiet_enforcer_embeds_ranked_actions_cost_analysis(tmp_path, monkeypatch):
+    repo_root = tmp_path / "Repo"
+    workflow = repo_root / ".github" / "workflows" / "validate.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        """name: Validate\non:\n  push: {}\njobs:\n  validate:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo pass\n""",
+        encoding="utf-8",
+    )
+
+    targets = tmp_path / "targets.json"
+    targets.write_text(
+        json.dumps({
+            "targets": [
+                {
+                    "repo": "StegVerse-Labs/Repo",
+                    "workflow": "validate.yml",
+                    "enabled": True,
+                    "run_hours_utc": [3],
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    receipt = tmp_path / "quiet.json"
+    policy = Path(__file__).resolve().parents[1] / "data" / "actions_cost_policy.json"
+
+    monkeypatch.setenv("TARGETS_FILE", str(targets))
+    monkeypatch.setenv("QUIET_RECEIPT", str(receipt))
+    monkeypatch.setenv("ACTIONS_COST_POLICY", str(policy))
+    monkeypatch.setenv("STEGVERSE_REPO_ROOTS_JSON", json.dumps({"StegVerse-Labs/Repo": str(repo_root)}))
+    for name in audit_schedules.FORBIDDEN_CREDENTIALS:
+        monkeypatch.delenv(name, raising=False)
+
+    assert audit_schedules.main() == 0
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["schema"] == "stegverse.healer.quiet-enforcer-receipt.v3"
+    assert payload["state"] == "COMPLETE"
+    assert payload["summary"]["violation_count"] == 0
+    assert payload["summary"]["cost_review_candidate_count"] >= 1
+    assert payload["cost_analysis"]["github_token_required"] is False
+    assert payload["cost_analysis"]["network_required"] is False
+    assert payload["cost_analysis"]["authority_effect"] == "NONE"
+    top = payload["cost_analysis"]["top_remediation_candidates"]
+    assert top
+    assert top[0]["workflow"].endswith("validate.yml")
+    assert "UNFILTERED_PUSH" in top[0]["review_reasons"]
+
+
+def test_quiet_enforcer_still_fails_repository_local_schedule(tmp_path, monkeypatch):
+    repo_root = tmp_path / "Repo"
+    workflow = repo_root / ".github" / "workflows" / "hourly.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        """name: Hourly\non:\n  schedule:\n    - cron: '0 * * * *'\njobs:\n  validate:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo pass\n""",
+        encoding="utf-8",
+    )
+    targets = tmp_path / "targets.json"
+    targets.write_text(json.dumps({"targets": [{"repo": "StegVerse-Labs/Repo", "workflow": "hourly.yml", "enabled": True}]}), encoding="utf-8")
+    receipt = tmp_path / "quiet.json"
+    policy = Path(__file__).resolve().parents[1] / "data" / "actions_cost_policy.json"
+
+    monkeypatch.setenv("TARGETS_FILE", str(targets))
+    monkeypatch.setenv("QUIET_RECEIPT", str(receipt))
+    monkeypatch.setenv("ACTIONS_COST_POLICY", str(policy))
+    monkeypatch.setenv("STEGVERSE_REPO_ROOTS_JSON", json.dumps({"StegVerse-Labs/Repo": str(repo_root)}))
+    for name in audit_schedules.FORBIDDEN_CREDENTIALS:
+        monkeypatch.delenv(name, raising=False)
+
+    assert audit_schedules.main() == 1
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["state"] == "FAILED"
+    assert payload["summary"]["violation_count"] == 1
+    assert payload["cost_analysis"]["scheduled_workflow_count"] == 1
+    assert payload["cost_analysis"]["estimated_scheduled_job_starts_per_month"] == 744.0

--- a/tests/test_quiet_enforcer_cost_integration.py
+++ b/tests/test_quiet_enforcer_cost_integration.py
@@ -1,80 +1,80 @@
 import json
+import os
+import tempfile
+import unittest
 from pathlib import Path
+from unittest import mock
 
 from app import audit_schedules
 
 
-def test_quiet_enforcer_embeds_ranked_actions_cost_analysis(tmp_path, monkeypatch):
-    repo_root = tmp_path / "Repo"
-    workflow = repo_root / ".github" / "workflows" / "validate.yml"
-    workflow.parent.mkdir(parents=True)
-    workflow.write_text(
-        """name: Validate\non:\n  push: {}\njobs:\n  validate:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo pass\n""",
-        encoding="utf-8",
-    )
+class QuietEnforcerCostIntegrationTests(unittest.TestCase):
+    def _env(self, targets: Path, receipt: Path, repo_root: Path) -> dict[str, str]:
+        policy = Path(__file__).resolve().parents[1] / "data" / "actions_cost_policy.json"
+        return {
+            "TARGETS_FILE": str(targets),
+            "QUIET_RECEIPT": str(receipt),
+            "ACTIONS_COST_POLICY": str(policy),
+            "STEGVERSE_REPO_ROOTS_JSON": json.dumps({"StegVerse-Labs/Repo": str(repo_root)}),
+        }
 
-    targets = tmp_path / "targets.json"
-    targets.write_text(
-        json.dumps({
-            "targets": [
-                {
-                    "repo": "StegVerse-Labs/Repo",
-                    "workflow": "validate.yml",
-                    "enabled": True,
-                    "run_hours_utc": [3],
-                }
-            ]
-        }),
-        encoding="utf-8",
-    )
-    receipt = tmp_path / "quiet.json"
-    policy = Path(__file__).resolve().parents[1] / "data" / "actions_cost_policy.json"
+    def test_quiet_enforcer_embeds_ranked_actions_cost_analysis(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            repo_root = tmp_path / "Repo"
+            workflow = repo_root / ".github" / "workflows" / "validate.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(
+                """name: Validate\non:\n  push: {}\njobs:\n  validate:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo pass\n""",
+                encoding="utf-8",
+            )
+            targets = tmp_path / "targets.json"
+            targets.write_text(json.dumps({"targets": [{"repo": "StegVerse-Labs/Repo", "workflow": "validate.yml", "enabled": True, "run_hours_utc": [3]}]}), encoding="utf-8")
+            receipt = tmp_path / "quiet.json"
+            env = self._env(targets, receipt, repo_root)
+            for name in audit_schedules.FORBIDDEN_CREDENTIALS:
+                env.pop(name, None)
+            clean = {k: v for k, v in os.environ.items() if k not in audit_schedules.FORBIDDEN_CREDENTIALS}
+            clean.update(env)
+            with mock.patch.dict(os.environ, clean, clear=True):
+                self.assertEqual(audit_schedules.main(), 0)
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(payload["schema"], "stegverse.healer.quiet-enforcer-receipt.v3")
+            self.assertEqual(payload["state"], "COMPLETE")
+            self.assertEqual(payload["summary"]["violation_count"], 0)
+            self.assertGreaterEqual(payload["summary"]["cost_review_candidate_count"], 1)
+            self.assertFalse(payload["cost_analysis"]["github_token_required"])
+            self.assertFalse(payload["cost_analysis"]["network_required"])
+            self.assertEqual(payload["cost_analysis"]["authority_effect"], "NONE")
+            top = payload["cost_analysis"]["top_remediation_candidates"]
+            self.assertTrue(top)
+            self.assertTrue(top[0]["workflow"].endswith("validate.yml"))
+            self.assertIn("UNFILTERED_PUSH", top[0]["review_reasons"])
 
-    monkeypatch.setenv("TARGETS_FILE", str(targets))
-    monkeypatch.setenv("QUIET_RECEIPT", str(receipt))
-    monkeypatch.setenv("ACTIONS_COST_POLICY", str(policy))
-    monkeypatch.setenv("STEGVERSE_REPO_ROOTS_JSON", json.dumps({"StegVerse-Labs/Repo": str(repo_root)}))
-    for name in audit_schedules.FORBIDDEN_CREDENTIALS:
-        monkeypatch.delenv(name, raising=False)
+    def test_quiet_enforcer_still_fails_repository_local_schedule(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            repo_root = tmp_path / "Repo"
+            workflow = repo_root / ".github" / "workflows" / "hourly.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(
+                """name: Hourly\non:\n  schedule:\n    - cron: '0 * * * *'\njobs:\n  validate:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo pass\n""",
+                encoding="utf-8",
+            )
+            targets = tmp_path / "targets.json"
+            targets.write_text(json.dumps({"targets": [{"repo": "StegVerse-Labs/Repo", "workflow": "hourly.yml", "enabled": True}]}), encoding="utf-8")
+            receipt = tmp_path / "quiet.json"
+            env = self._env(targets, receipt, repo_root)
+            clean = {k: v for k, v in os.environ.items() if k not in audit_schedules.FORBIDDEN_CREDENTIALS}
+            clean.update(env)
+            with mock.patch.dict(os.environ, clean, clear=True):
+                self.assertEqual(audit_schedules.main(), 1)
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(payload["state"], "FAILED")
+            self.assertEqual(payload["summary"]["violation_count"], 1)
+            self.assertEqual(payload["cost_analysis"]["scheduled_workflow_count"], 1)
+            self.assertEqual(payload["cost_analysis"]["estimated_scheduled_job_starts_per_month"], 744.0)
 
-    assert audit_schedules.main() == 0
-    payload = json.loads(receipt.read_text(encoding="utf-8"))
-    assert payload["schema"] == "stegverse.healer.quiet-enforcer-receipt.v3"
-    assert payload["state"] == "COMPLETE"
-    assert payload["summary"]["violation_count"] == 0
-    assert payload["summary"]["cost_review_candidate_count"] >= 1
-    assert payload["cost_analysis"]["github_token_required"] is False
-    assert payload["cost_analysis"]["network_required"] is False
-    assert payload["cost_analysis"]["authority_effect"] == "NONE"
-    top = payload["cost_analysis"]["top_remediation_candidates"]
-    assert top
-    assert top[0]["workflow"].endswith("validate.yml")
-    assert "UNFILTERED_PUSH" in top[0]["review_reasons"]
 
-
-def test_quiet_enforcer_still_fails_repository_local_schedule(tmp_path, monkeypatch):
-    repo_root = tmp_path / "Repo"
-    workflow = repo_root / ".github" / "workflows" / "hourly.yml"
-    workflow.parent.mkdir(parents=True)
-    workflow.write_text(
-        """name: Hourly\non:\n  schedule:\n    - cron: '0 * * * *'\njobs:\n  validate:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo pass\n""",
-        encoding="utf-8",
-    )
-    targets = tmp_path / "targets.json"
-    targets.write_text(json.dumps({"targets": [{"repo": "StegVerse-Labs/Repo", "workflow": "hourly.yml", "enabled": True}]}), encoding="utf-8")
-    receipt = tmp_path / "quiet.json"
-    policy = Path(__file__).resolve().parents[1] / "data" / "actions_cost_policy.json"
-
-    monkeypatch.setenv("TARGETS_FILE", str(targets))
-    monkeypatch.setenv("QUIET_RECEIPT", str(receipt))
-    monkeypatch.setenv("ACTIONS_COST_POLICY", str(policy))
-    monkeypatch.setenv("STEGVERSE_REPO_ROOTS_JSON", json.dumps({"StegVerse-Labs/Repo": str(repo_root)}))
-    for name in audit_schedules.FORBIDDEN_CREDENTIALS:
-        monkeypatch.delenv(name, raising=False)
-
-    assert audit_schedules.main() == 1
-    payload = json.loads(receipt.read_text(encoding="utf-8"))
-    assert payload["state"] == "FAILED"
-    assert payload["summary"]["violation_count"] == 1
-    assert payload["cost_analysis"]["scheduled_workflow_count"] == 1
-    assert payload["cost_analysis"]["estimated_scheduled_job_starts_per_month"] == 744.0
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a credential-free, network-free analyzer for ranking GitHub Actions cost pressure across locally materialized StegVerse repositories. It inventories schedules, broad push/PR triggers, missing concurrency cancellation, literal matrix fanout, and artifact custody, then ranks remediation candidates and prefers reuse of the existing sovereign Healer scheduler for recurring non-authoritative work.

No GitHub token, provider secret, Render path, second scheduler, heartbeat, runtime authority, publication authority, custody authority, wallet authority, or automatic workflow mutation is introduced.

Canonical continuation: `docs/GITHUB_ACTIONS_COST_REDUCTION_MIRROR_HANDOFF.md`.

Activation remains open until the analyzer is executed against current repository roots and at least one evidence-preserving migration measurably reduces expected hosted runner starts without capability loss.