### PR TITLE
Validate Test Readiness fanout narrowing

### DIFF
--- a/data/actions-fanout/test-readiness-37-validation.json
+++ b/data/actions-fanout/test-readiness-37-validation.json
@@ -2,13 +2,23 @@
   "schema_version": "1.0.0",
   "goal_id": "HEALER-TEST-READINESS-FANOUT-037",
   "issue": 37,
-  "purpose": "Trigger one exact PR validation after documentation-only fanout narrowing.",
-  "expected_trigger_behavior": {
+  "validation_pull_request": 38,
+  "validated_head": "01db8f61111ee0df8a0296985288473d764bf70c",
+  "workflow_run": 32601378334,
+  "workflow_job": 97100031649,
+  "result": "PASS",
+  "validated_behavior": {
     "docs_only_push_or_pull_request": false,
     "root_readme_only_push_or_pull_request": false,
     "non_documentation_push_or_pull_request": true,
     "workflow_dispatch": true,
-    "cancel_in_progress": true
+    "cancel_in_progress": true,
+    "credential_refusal": "PASS",
+    "anonymous_exact_source_fetch": "PASS",
+    "baseline_repository_smoke": "PASS",
+    "deterministic_tests": "PASS",
+    "failure_mailbox_benchmark": "PASS",
+    "validation_only_authority_boundary": "PASS"
   },
   "authority": {
     "credential_authority": "TV/TVC",
@@ -18,5 +28,5 @@
     "runtime_effect": false,
     "activation_effect": false
   },
-  "state": "AWAITING_EXACT_PR_VALIDATION"
+  "state": "EXACT_PR_VALIDATION_PASS"
 }

--- a/data/actions-fanout/test-readiness-37-validation.json
+++ b/data/actions-fanout/test-readiness-37-validation.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0.0",
+  "goal_id": "HEALER-TEST-READINESS-FANOUT-037",
+  "issue": 37,
+  "purpose": "Trigger one exact PR validation after documentation-only fanout narrowing.",
+  "expected_trigger_behavior": {
+    "docs_only_push_or_pull_request": false,
+    "root_readme_only_push_or_pull_request": false,
+    "non_documentation_push_or_pull_request": true,
+    "workflow_dispatch": true,
+    "cancel_in_progress": true
+  },
+  "authority": {
+    "credential_authority": "TV/TVC",
+    "github_actions_production_role": "NONE",
+    "github_token_runtime_authority": "NONE",
+    "render_required": false,
+    "runtime_effect": false,
+    "activation_effect": false
+  },
+  "state": "AWAITING_EXACT_PR_VALIDATION"
+}

--- a/docs/TEST_READINESS_FANOUT_REPAIR_MIRROR_HANDOFF.md
+++ b/docs/TEST_READINESS_FANOUT_REPAIR_MIRROR_HANDOFF.md
@@ -9,30 +9,53 @@ Reduce redundant hosted validation in `StegVerse-Labs/StegVerse-Healer/.github/w
 ```text
 goal_id: HEALER-TEST-READINESS-FANOUT-037
 repository: StegVerse-Labs/StegVerse-Healer
-branch: fix/test-readiness-fanout-37
+branch: main
 credential_authority: TV/TVC
 non_tv_tvc_secret_or_token_allowed: false
 github_actions_production_role: NONE
 render_required: false
-state: IMPLEMENTATION_IN_PROGRESS
+state: SOURCE_REPAIRED_EXACT_PR_VALIDATION_PASS
 ```
 
-## Proven current-main fanout
+## Proven fanout defect
 
-Before this repair, Test Readiness has unfiltered `push:` and `pull_request:` triggers and no concurrency cancellation. Every qualifying repository change launches the full credential-clean validation job: anonymous exact-source fetch, baseline JSON/repository smoke, the complete deterministic unittest suite, failure-mailbox benchmark, and authority-boundary validation.
+Before this repair, Test Readiness had unfiltered `push:` and `pull_request:` triggers and no concurrency cancellation. Every repository change launched the full credential-clean validation job: anonymous exact-source fetch, baseline JSON/repository smoke, the complete deterministic unittest suite, failure-mailbox benchmark, and authority-boundary validation.
 
-This run itself demonstrated avoidable duplication: source-changing PR #36 required exact-head validation, while evidence-only handoff updates also started the same full 87-test + benchmark lane despite not changing executable/config/schema/test surfaces.
+Healer #35 / PR #36 demonstrated avoidable duplication when evidence-only `docs/**` handoff updates started the same full 87-test + benchmark lane despite changing no executable/config/schema/test surface.
 
-## Safe repair boundary
+## Installed repair
 
-- Keep automatic `push` and `pull_request` validation for all repository content except documentation-only `docs/**` and root `README.md` changes.
-- Keep `workflow_dispatch` for intentional full validation.
-- Add per-PR/ref concurrency with `cancel-in-progress: true` so superseded runs on the same change stream do not consume full hosted runner time.
-- Preserve `permissions: {}`, credential refusal, anonymous exact-source fetch, full deterministic tests, benchmark, and validation-only authority boundary.
-- Do not move runtime/control-plane authority into Actions.
+Current `main` commit `ad54838259534b5526c5b713bbcef1b3538ae9fd` changes only workflow admission semantics:
 
-Documentation-only commits can still be intentionally checked through `workflow_dispatch`; code, actions, data/config, failure-mailbox, handoff JSON, registry, schema, scripts, templates, tests, and root source files continue to trigger automatically.
+- automatic `push` and `pull_request` validation remains for repository content other than documentation-only `docs/**` and root `README.md` changes;
+- `workflow_dispatch` remains available for intentional full validation;
+- per-PR/ref concurrency uses `cancel-in-progress: true`;
+- `permissions: {}`, credential refusal, anonymous exact-source fetch, full deterministic tests, benchmark, and validation-only authority boundary are unchanged;
+- no runtime/control-plane authority moved into GitHub Actions.
+
+Documentation-only commits can still be intentionally checked through `workflow_dispatch`; code, Actions, data/config, failure-mailbox, handoff JSON, registry, schema, scripts, templates, tests, and root source files continue to trigger automatically.
+
+## Exact qualifying validation
+
+A deliberately non-documentation machine-evidence change was opened as PR #38 to prove that the narrowed workflow still automatically validates qualifying changes.
+
+```text
+validation_pr: 38
+validation_head_initial: 01db8f61111ee0df8a0296985288473d764bf70c
+Test Readiness run: 32601378334
+job: 97100031649
+result: SUCCESS
+credential refusal: PASS
+anonymous exact-source fetch: PASS
+baseline repository smoke: PASS
+deterministic Healer tests: PASS
+failure mailbox product benchmark: PASS
+validation-only authority boundary: PASS
+machine evidence: data/actions-fanout/test-readiness-37-validation.json
+```
+
+This is validation evidence only. It does not establish or grant sovereign runtime, production, activation, publication, custody, release, wallet, provider, or scheduler authority.
 
 ## Completion gate
 
-Requires real workflow mutation, exact changed-head validation, merge to main, and evidence that source/schema/config/test automatic coverage and manual dispatch remain present. A workflow pass is validation evidence only, not runtime activation.
+The source repair and an exact qualifying PR validation are proven. Final completion requires the evidence-bearing PR head itself to pass Test Readiness, merge to `main`, and issue #37 closeout to record the resulting merge. Until then the goal remains open.


### PR DESCRIPTION
Evidence-only validation for Healer #37. The only change is a machine-readable fanout-validation marker outside `docs/**`/README, so the narrowed Test Readiness workflow should still trigger automatically. No runtime, control-plane, credential, token, Render, production, activation, publication, custody, or release authority is introduced.