### PR TITLE
Migrate Site Executive Rhetoric Ledger sync to sovereign scheduler

### DIFF
--- a/app/site_erl_sync.py
+++ b/app/site_erl_sync.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+FORBIDDEN_CREDENTIALS = (
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_PAT",
+    "HEALER_GH_TOKEN",
+    "HEALER_PAT",
+    "GH_STEGVERSE_AI_TOKEN",
+    "STEGVERSE_CROSS_REPO_READ_TOKEN",
+)
+
+
+def _blocked(base: dict[str, Any], outcome: str, **extra: Any) -> dict[str, Any]:
+    return {**base, "state": "BLOCKED", "outcome": outcome, **extra}
+
+
+def execute_site_erl_sync(
+    target: dict[str, Any],
+    roots: dict[str, Path],
+    base: dict[str, Any],
+) -> dict[str, Any]:
+    present = [name for name in FORBIDDEN_CREDENTIALS if os.getenv(name)]
+    if present:
+        return _blocked(base, "SITE_ERL_SYNC_FORBIDDEN_CREDENTIAL_ENV", forbidden=sorted(present))
+
+    site_root = roots.get("StegVerse-Labs/Site")
+    source_repo = str(target.get("source_repository", "StegVerse-Labs/Executive_Rhetoric_Ledger"))
+    source_root = roots.get(source_repo)
+    if site_root is None:
+        return _blocked(base, "SITE_ERL_SYNC_SITE_ROOT_NOT_MATERIALIZED")
+    if source_root is None:
+        return _blocked(base, "SITE_ERL_SYNC_SOURCE_ROOT_NOT_MATERIALIZED", source_repository=source_repo)
+
+    source_rel = Path(str(target.get("source_path", "publication/compendium.json")))
+    destination_rel = Path(str(target.get("destination_path", "public/data/executive-rhetoric-ledger/compendium.json")))
+    acknowledgment_rel = Path(str(target.get("acknowledgment_path", "receipts/executive-rhetoric-ledger-ack.json")))
+    source_path = source_root / source_rel
+    destination_path = site_root / destination_rel
+    acknowledgment_path = site_root / acknowledgment_rel
+
+    if not source_path.is_file():
+        return _blocked(base, "SITE_ERL_SYNC_SOURCE_MISSING", source_path=str(source_rel))
+
+    try:
+        source_bytes = source_path.read_bytes()
+        source_json = json.loads(source_bytes.decode("utf-8"))
+    except Exception as exc:
+        return _blocked(base, "SITE_ERL_SYNC_SOURCE_INVALID_JSON", source_path=str(source_rel), error=str(exc))
+    if not isinstance(source_json, (dict, list)):
+        return _blocked(base, "SITE_ERL_SYNC_SOURCE_INVALID_SHAPE", source_path=str(source_rel))
+
+    source_sha256 = hashlib.sha256(source_bytes).hexdigest()
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    destination_path.write_bytes(source_bytes)
+    destination_bytes = destination_path.read_bytes()
+    destination_sha256 = hashlib.sha256(destination_bytes).hexdigest()
+    byte_equal = destination_bytes == source_bytes
+    if not byte_equal or destination_sha256 != source_sha256:
+        return _blocked(
+            base,
+            "SITE_ERL_SYNC_DESTINATION_IDENTITY_MISMATCH",
+            source_sha256=source_sha256,
+            destination_sha256=destination_sha256,
+        )
+
+    receipt = {
+        "schema": "stegverse.healer.site_erl_sync_receipt/v0.1",
+        "state": "PASS",
+        "canonical_owner": "StegVerse-Labs/StegVerse-Healer#39",
+        "source_repository": source_repo,
+        "source_path": str(source_rel),
+        "source_sha256": source_sha256,
+        "destination_repository": "StegVerse-Labs/Site",
+        "destination_path": str(destination_rel),
+        "destination_sha256": destination_sha256,
+        "byte_equal": True,
+        "acknowledgment_owned_by_destination": True,
+        "source_self_acknowledgment_allowed": False,
+        "credential_authority": "TV/TVC",
+        "github_token_required": False,
+        "remote_checkout_required": False,
+        "artifact_custody_required": False,
+        "repository_writeback_authority": False,
+        "local_materialization_mutation": True,
+        "runtime_authority": False,
+        "publication_authority": False,
+        "activation_authority": False,
+    }
+    receipt["receipt_sha256"] = hashlib.sha256(
+        json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    acknowledgment_path.parent.mkdir(parents=True, exist_ok=True)
+    acknowledgment_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return {
+        **base,
+        "state": "COMPLETE",
+        "outcome": "SOVEREIGN_LOCAL_SITE_ERL_SYNC",
+        "receipt": receipt,
+    }

--- a/app/sovereign_scheduler.py
+++ b/app/sovereign_scheduler.py
@@ -128,6 +128,10 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
                 return {**base, "state": "BLOCKED", "outcome": "SITE_LOCAL_ORCHESTRATION_BLOCKED", "execution": results}
         return {**base, "state": "COMPLETE", "outcome": "SOVEREIGN_LOCAL_SITE_ORCHESTRATION", "execution": results}
 
+    if repo == "StegVerse-Labs/Site" and workflow == "executive-rhetoric-ledger-local-sync":
+        from app.site_erl_sync import execute_site_erl_sync
+        return execute_site_erl_sync(target, roots, base)
+
     if repo == "StegVerse-Labs/Site" and workflow == "site-b27-native-validation":
         local_forbidden = (
             "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "TVC_EPHEMERAL_GITHUB_TOKEN",

--- a/data/orchestrator_targets.json
+++ b/data/orchestrator_targets.json
@@ -53,6 +53,21 @@
     },
     {
       "repo": "StegVerse-Labs/Site",
+      "workflow": "executive-rhetoric-ledger-local-sync",
+      "ref": "main",
+      "enabled": true,
+      "aliases": ["site-erl-sync", "executive-rhetoric-ledger-sync", "erl-sync"],
+      "run_hours_utc": [14],
+      "inputs": {},
+      "canonical_owner": "StegVerse-Labs/StegVerse-Healer#39",
+      "source_repository": "StegVerse-Labs/Executive_Rhetoric_Ledger",
+      "source_path": "publication/compendium.json",
+      "destination_path": "public/data/executive-rhetoric-ledger/compendium.json",
+      "acknowledgment_path": "receipts/executive-rhetoric-ledger-ack.json",
+      "status": "sovereign-local-daily-mirror-no-github-token-no-remote-checkout-no-artifact-custody"
+    },
+    {
+      "repo": "StegVerse-Labs/Site",
       "workflow": "heartbeat-response-sovereign-carrier",
       "ref": "main",
       "enabled": true,

--- a/tests/test_site_erl_sync.py
+++ b/tests/test_site_erl_sync.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.site_erl_sync import execute_site_erl_sync
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSiteErlSync(unittest.TestCase):
+    def target(self) -> dict:
+        config = json.loads((ROOT / "data" / "orchestrator_targets.json").read_text(encoding="utf-8"))
+        matches = [
+            target for target in config["targets"]
+            if target.get("repo") == "StegVerse-Labs/Site"
+            and target.get("workflow") == "executive-rhetoric-ledger-local-sync"
+        ]
+        self.assertEqual(len(matches), 1)
+        return matches[0]
+
+    def test_target_uses_existing_daily_scheduler_without_token_metadata(self):
+        target = self.target()
+        self.assertEqual(target["run_hours_utc"], [14])
+        self.assertEqual(target["source_repository"], "StegVerse-Labs/Executive_Rhetoric_Ledger")
+        self.assertEqual(target["source_path"], "publication/compendium.json")
+        self.assertEqual(target["destination_path"], "public/data/executive-rhetoric-ledger/compendium.json")
+        serialized = json.dumps(target).lower().replace("no-github-token", "")
+        self.assertNotIn("github_token", serialized)
+        self.assertNotIn("gh_token", serialized)
+
+    def test_local_copy_hash_and_destination_acknowledgment(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            site = base / "Site"
+            source = base / "Executive_Rhetoric_Ledger"
+            (source / "publication").mkdir(parents=True)
+            site.mkdir()
+            payload = {"schema_version": "test", "entries": [{"id": "ERL-1", "claim": "bounded"}]}
+            source_bytes = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+            (source / "publication" / "compendium.json").write_bytes(source_bytes)
+            roots = {
+                "StegVerse-Labs/Site": site,
+                "StegVerse-Labs/Executive_Rhetoric_Ledger": source,
+            }
+            result = execute_site_erl_sync(self.target(), roots, {"repo": "StegVerse-Labs/Site", "workflow": "executive-rhetoric-ledger-local-sync"})
+            self.assertEqual(result["state"], "COMPLETE")
+            self.assertEqual(result["outcome"], "SOVEREIGN_LOCAL_SITE_ERL_SYNC")
+            destination = site / "public/data/executive-rhetoric-ledger/compendium.json"
+            acknowledgment = site / "receipts/executive-rhetoric-ledger-ack.json"
+            self.assertEqual(destination.read_bytes(), source_bytes)
+            receipt = json.loads(acknowledgment.read_text(encoding="utf-8"))
+            self.assertEqual(receipt["state"], "PASS")
+            self.assertTrue(receipt["byte_equal"])
+            self.assertEqual(receipt["source_sha256"], receipt["destination_sha256"])
+            self.assertTrue(receipt["acknowledgment_owned_by_destination"])
+            self.assertFalse(receipt["source_self_acknowledgment_allowed"])
+            self.assertFalse(receipt["github_token_required"])
+            self.assertFalse(receipt["remote_checkout_required"])
+            self.assertFalse(receipt["artifact_custody_required"])
+            self.assertFalse(receipt["repository_writeback_authority"])
+            self.assertFalse(receipt["runtime_authority"])
+            self.assertFalse(receipt["publication_authority"])
+            self.assertFalse(receipt["activation_authority"])
+
+    def test_missing_source_root_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site = Path(temp_dir) / "Site"
+            site.mkdir()
+            result = execute_site_erl_sync(
+                self.target(),
+                {"StegVerse-Labs/Site": site},
+                {"repo": "StegVerse-Labs/Site", "workflow": "executive-rhetoric-ledger-local-sync"},
+            )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_ERL_SYNC_SOURCE_ROOT_NOT_MATERIALIZED")
+
+    def test_missing_source_file_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            site = base / "Site"
+            source = base / "Executive_Rhetoric_Ledger"
+            site.mkdir(); source.mkdir()
+            result = execute_site_erl_sync(
+                self.target(),
+                {"StegVerse-Labs/Site": site, "StegVerse-Labs/Executive_Rhetoric_Ledger": source},
+                {"repo": "StegVerse-Labs/Site", "workflow": "executive-rhetoric-ledger-local-sync"},
+            )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_ERL_SYNC_SOURCE_MISSING")
+
+    def test_invalid_json_fails_closed_without_destination_ack(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            site = base / "Site"
+            source = base / "Executive_Rhetoric_Ledger"
+            (source / "publication").mkdir(parents=True)
+            site.mkdir()
+            (source / "publication" / "compendium.json").write_text("{bad json", encoding="utf-8")
+            result = execute_site_erl_sync(
+                self.target(),
+                {"StegVerse-Labs/Site": site, "StegVerse-Labs/Executive_Rhetoric_Ledger": source},
+                {"repo": "StegVerse-Labs/Site", "workflow": "executive-rhetoric-ledger-local-sync"},
+            )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_ERL_SYNC_SOURCE_INVALID_JSON")
+            self.assertFalse((site / "public/data/executive-rhetoric-ledger/compendium.json").exists())
+            self.assertFalse((site / "receipts/executive-rhetoric-ledger-ack.json").exists())
+
+    def test_github_credentials_fail_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            site = base / "Site"
+            source = base / "Executive_Rhetoric_Ledger"
+            (source / "publication").mkdir(parents=True)
+            site.mkdir()
+            (source / "publication" / "compendium.json").write_text("{}\n", encoding="utf-8")
+            roots = {"StegVerse-Labs/Site": site, "StegVerse-Labs/Executive_Rhetoric_Ledger": source}
+            with patch.dict(os.environ, {"GITHUB_TOKEN": "forbidden"}, clear=False):
+                result = execute_site_erl_sync(
+                    self.target(), roots,
+                    {"repo": "StegVerse-Labs/Site", "workflow": "executive-rhetoric-ledger-local-sync"},
+                )
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "SITE_ERL_SYNC_FORBIDDEN_CREDENTIAL_ENV")
+            self.assertIn("GITHUB_TOKEN", result["forbidden"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements Healer #39 using the existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001` scheduler only.

Changes:
- adds fixed daily target `StegVerse-Labs/Site / executive-rhetoric-ledger-local-sync` at 14 UTC;
- adds bounded local handler `app/site_erl_sync.py` using only materialized `StegVerse-Labs/Executive_Rhetoric_Ledger` and `StegVerse-Labs/Site` roots;
- validates `publication/compendium.json` as JSON, copies exact bytes to `Site/public/data/executive-rhetoric-ledger/compendium.json`, verifies SHA-256 identity, and writes a destination-owned local acknowledgment receipt;
- wires that fixed handler into the existing scheduler;
- adds deterministic tests for target cadence, byte/hash identity, destination acknowledgment ownership, missing roots/source, invalid JSON, and GitHub-token refusal.

No remote checkout. No GitHub token/PAT. No artifact custody. No GitHub PR/writeback authority. No second scheduler or heartbeat. No Render. TV/TVC remains credential authority. The local destination mutation is materialization only and grants no runtime/provider/publication/activation authority.

This PR is source/integration only. Site may retire `.github/workflows/sync-executive-rhetoric-ledger.yml` only after Test Readiness passes, this source is merged, and Site proves parity on exact-current main. Live scheduler activation remains separately MACHINE_OWNED and is not inferred from CI.