### PR TITLE
Bind Coinbase Gateway to sovereign StegDeploy execution

### DIFF
--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -31,8 +31,8 @@ class GatewayActivationError(ValueError):
     pass
 
 
-def load_roots() -> dict[str, Path]:
-    raw = os.getenv("STEGVERSE_REPO_ROOTS_JSON", "").strip()
+def load_roots(raw_override: str | None = None) -> dict[str, Path]:
+    raw = (raw_override if raw_override is not None else os.getenv("STEGVERSE_REPO_ROOTS_JSON", "")).strip()
     if not raw:
         raise GatewayActivationError("STEGVERSE_REPO_ROOTS_JSON_REQUIRED")
     value = json.loads(raw)
@@ -115,8 +115,8 @@ def _clean_env(decision: dict[str, Any]) -> dict[str, str]:
     return env
 
 
-def execute() -> dict[str, Any]:
-    roots = load_roots()
+def execute(roots_json: str | None = None) -> dict[str, Any]:
+    roots = load_roots(roots_json)
     llm_root = roots.get(LLM_REPO)
     tvc_root = roots.get(TVC_REPO)
     if llm_root is None:

--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+LLM_REPO = "StegVerse-org/LLM-adapter"
+TVC_REPO = "StegVerse-Labs/TVC"
+ROLE = "service_gateway_coinbase_skap_ciphertext_intake"
+READINESS_URL = "http://127.0.0.1:8000/api/coinbase/skap/readiness"
+FORBIDDEN_ENV = (
+    "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
+    "GH_STEGVERSE_AI_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    "STEGVERSE_PROVIDER_TOKEN", "STEGVERSE_MASTER_RECORDS_TOKEN",
+    "STEGVERSE_EXTERNAL_REVIEW_SUBMIT_TOKEN", "STEGVERSE_EXTERNAL_REVIEW_RECEIPT_KEY",
+)
+DECISION_CANDIDATES = (
+    "receipts/coinbase/service-gateway-intake-decision.json",
+    "runtime/coinbase/service-gateway-intake-decision.json",
+    "receipts/service-gateway/coinbase-skap-intake-decision.json",
+)
+
+
+class GatewayActivationError(ValueError):
+    pass
+
+
+def load_roots() -> dict[str, Path]:
+    raw = os.getenv("STEGVERSE_REPO_ROOTS_JSON", "").strip()
+    if not raw:
+        raise GatewayActivationError("STEGVERSE_REPO_ROOTS_JSON_REQUIRED")
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise GatewayActivationError("STEGVERSE_REPO_ROOTS_JSON_OBJECT_REQUIRED")
+    result: dict[str, Path] = {}
+    for repo, path in value.items():
+        if isinstance(repo, str) and isinstance(path, str):
+            root = Path(path).expanduser().resolve()
+            if root.is_dir():
+                result[repo] = root
+    return result
+
+
+def validate_decision(receipt: dict[str, Any]) -> None:
+    if receipt.get("role") != ROLE:
+        raise GatewayActivationError("TVC_DECISION_ROLE_INVALID")
+    if receipt.get("admissible") is not True or receipt.get("binding_matched") is not True:
+        raise GatewayActivationError("TVC_DECISION_NOT_ADMISSIBLE")
+    if list(receipt.get("allowed_keys") or []) != [] or list(receipt.get("denied_keys") or []) != []:
+        raise GatewayActivationError("TVC_DECISION_NO_VALUE_SCOPE_INVALID")
+    if receipt.get("credential_values_available") not in (None, False):
+        raise GatewayActivationError("TVC_DECISION_CREDENTIAL_VALUE_SCOPE_FORBIDDEN")
+    if not isinstance(receipt.get("decision_id"), str) or not receipt.get("decision_id"):
+        raise GatewayActivationError("TVC_DECISION_ID_MISSING")
+
+
+def locate_decision(tvc_root: Path) -> tuple[Path, dict[str, Any]]:
+    explicit = os.getenv("STEGVERSE_COINBASE_GATEWAY_TVC_DECISION_RECEIPT_FILE", "").strip()
+    candidates = [Path(explicit).expanduser().resolve()] if explicit else []
+    candidates.extend((tvc_root / rel).resolve() for rel in DECISION_CANDIDATES)
+    for path in candidates:
+        if not path.is_file():
+            continue
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            continue
+        validate_decision(value)
+        return path, value
+    raise GatewayActivationError("TVC_NO_VALUE_GATEWAY_DECISION_NOT_MATERIALIZED")
+
+
+def validate_readiness(payload: dict[str, Any], decision: dict[str, Any]) -> None:
+    expected = {
+        "state": "READY",
+        "service_id": "stegverse-service-gateway",
+        "adapter": "coinbase-skap-ciphertext-staging",
+        "transport_protocol": "InTr",
+        "completed_boundary": "DEVICE_TO_KV",
+        "credential_authority": "TV/TVC",
+        "gateway_credential_value_access": False,
+        "gateway_decryption_authority": False,
+        "gateway_execution_authority": "NONE",
+        "tvc_admission_completed": False,
+        "skap_vault_admission_completed": False,
+        "next_required_transition": "KV_SKAP_VAULT_INTERLOCK_ADMISSION",
+        "tvc_decision_id": decision["decision_id"],
+    }
+    failed = [key for key, value in expected.items() if payload.get(key) != value]
+    if failed:
+        raise GatewayActivationError("READINESS_BOUNDARY_INVALID:" + ",".join(sorted(failed)))
+
+
+def _clean_env(decision: dict[str, Any]) -> dict[str, str]:
+    present = [name for name in FORBIDDEN_ENV if os.getenv(name)]
+    if present:
+        raise GatewayActivationError("FORBIDDEN_CREDENTIAL_ENV:" + ",".join(sorted(present)))
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", str(Path.home())),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "LC_ALL": os.environ.get("LC_ALL", "C.UTF-8"),
+        "STEGVERSE_COINBASE_SKAP_TVC_DECISION_RECEIPT": json.dumps(decision, sort_keys=True),
+        "STEGVERSE_PROVIDER_ENABLED": "false",
+        "STEGVERSE_EXTERNAL_MUTATION_ENABLED": "false",
+    }
+    for name in ("XDG_STATE_HOME", "XDG_CONFIG_HOME"):
+        if os.getenv(name):
+            env[name] = os.environ[name]
+    return env
+
+
+def execute() -> dict[str, Any]:
+    roots = load_roots()
+    llm_root = roots.get(LLM_REPO)
+    tvc_root = roots.get(TVC_REPO)
+    if llm_root is None:
+        raise GatewayActivationError("LLM_ADAPTER_LOCAL_REPOSITORY_NOT_MATERIALIZED")
+    if tvc_root is None:
+        raise GatewayActivationError("TVC_LOCAL_REPOSITORY_NOT_MATERIALIZED")
+
+    required = (
+        llm_root / "scripts/stegdeploy_bootstrap.py",
+        llm_root / "compose.stegdeploy.yaml",
+        llm_root / "llm_adapter/deployed_gateway.py",
+        llm_root / "llm_adapter/service_gateway_composed.py",
+    )
+    missing = [str(path.relative_to(llm_root)) for path in required if not path.is_file()]
+    if missing:
+        raise GatewayActivationError("LLM_ADAPTER_STEGDEPLOY_SOURCE_INCOMPLETE:" + ",".join(missing))
+
+    decision_path, decision = locate_decision(tvc_root)
+    env = _clean_env(decision)
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=llm_root, env={"PATH": env["PATH"]},
+        text=True, capture_output=True, check=False, timeout=30,
+    )
+    source_head = head.stdout.strip().lower()
+    if head.returncode != 0 or len(source_head) != 40:
+        raise GatewayActivationError("LLM_ADAPTER_SOURCE_HEAD_UNPROVEN")
+
+    deploy = subprocess.run(
+        [sys.executable, "scripts/stegdeploy_bootstrap.py", "deploy", "--health-url", "http://127.0.0.1:8000/health"],
+        cwd=llm_root, env=env, text=True, capture_output=True, check=False, timeout=900,
+    )
+    if deploy.returncode != 0:
+        return {
+            "schema": "stegverse.healer.coinbase_stegdeploy_gateway_activation/v1",
+            "state": "BLOCKED",
+            "outcome": "STEGDEPLOY_BOOTSTRAP_BLOCKED",
+            "source_head": source_head,
+            "decision_ref": str(decision_path),
+            "returncode": deploy.returncode,
+            "stderr_tail": deploy.stderr[-2000:],
+            "credential_authority": "TV/TVC",
+            "github_token_required": False,
+            "provider_operation_started": False,
+            "production_public_route_observed": False,
+            "authority_effect": "NONE",
+        }
+
+    try:
+        with urllib.request.urlopen(READINESS_URL, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        raise GatewayActivationError("LOCAL_COINBASE_READINESS_UNAVAILABLE:" + type(exc).__name__) from exc
+    if not isinstance(payload, dict):
+        raise GatewayActivationError("LOCAL_COINBASE_READINESS_OBJECT_REQUIRED")
+    validate_readiness(payload, decision)
+
+    return {
+        "schema": "stegverse.healer.coinbase_stegdeploy_gateway_activation/v1",
+        "state": "COMPLETE",
+        "outcome": "LOCAL_SOVEREIGN_COINBASE_GATEWAY_READY",
+        "source_head": source_head,
+        "decision_ref": str(decision_path),
+        "decision_id": decision["decision_id"],
+        "readiness_url": READINESS_URL,
+        "readiness": payload,
+        "credential_authority": "TV/TVC",
+        "credential_material_present": False,
+        "github_token_required": False,
+        "render_required": False,
+        "network_source_fetch_performed": False,
+        "provider_operation_started": False,
+        "may_authorize_order": False,
+        "production_public_route_observed": False,
+        "authority_effect": "LOCAL_RUNTIME_OBSERVATION_ONLY",
+    }
+
+
+def main() -> int:
+    state_path_raw = os.getenv("HEALER_COINBASE_GATEWAY_STATE", "").strip()
+    state_path = Path(state_path_raw).expanduser().resolve() if state_path_raw else None
+    try:
+        result = execute()
+    except Exception as exc:
+        result = {
+            "schema": "stegverse.healer.coinbase_stegdeploy_gateway_activation/v1",
+            "state": "BLOCKED",
+            "outcome": str(exc),
+            "credential_authority": "TV/TVC",
+            "credential_material_present": False,
+            "github_token_required": False,
+            "render_required": False,
+            "provider_operation_started": False,
+            "production_public_route_observed": False,
+            "authority_effect": "NONE",
+        }
+    if state_path is not None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result.get("state") == "COMPLETE" else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/sovereign_scheduler.py
+++ b/app/sovereign_scheduler.py
@@ -303,6 +303,24 @@ def _execute_target(target: dict[str, Any], roots: dict[str, Path], all_roots_js
         state = "COMPLETE" if result["returncode"] == 0 and payload and payload.get("state") in {"COMPLETE","NOOP_ALREADY_VERIFIED"} else "BLOCKED"
         return {**base,"state":state,"outcome":"SOVEREIGN_LOCAL_STEGDEPLOY_RELAY","receipt":payload,"execution":result}
 
+    if repo == "StegVerse-org/LLM-adapter" and workflow == "coinbase-stegdeploy-sovereign-gateway":
+        from app.coinbase_stegdeploy_gateway import execute as execute_coinbase_gateway
+        try:
+            payload = execute_coinbase_gateway(all_roots_json)
+        except Exception as exc:
+            payload = {
+                "schema":"stegverse.healer.coinbase_stegdeploy_gateway_activation/v1",
+                "state":"BLOCKED",
+                "outcome":str(exc),
+                "credential_authority":"TV/TVC",
+                "github_token_required":False,
+                "provider_operation_started":False,
+                "production_public_route_observed":False,
+                "authority_effect":"NONE",
+            }
+        state = "COMPLETE" if payload.get("state") == "COMPLETE" else "BLOCKED"
+        return {**base,"state":state,"outcome":"SOVEREIGN_LOCAL_COINBASE_STEGDEPLOY_GATEWAY","receipt":payload}
+
     return {**base, "state": "REVIEW_REQUIRED", "outcome": "NO_SOVEREIGN_HANDLER_BOUND"}
 
 

--- a/data/orchestrator_targets.json
+++ b/data/orchestrator_targets.json
@@ -6,18 +6,9 @@
       "workflow": "site-task-runner.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "site"
-      ],
-      "run_hours_utc": [
-        0,
-        6,
-        12,
-        18
-      ],
-      "inputs": {
-        "task": "all-local"
-      },
+      "aliases": ["site"],
+      "run_hours_utc": [0, 6, 12, 18],
+      "inputs": {"task": "all-local"},
       "status": "sovereign-local-handler-bound"
     },
     {
@@ -25,17 +16,8 @@
       "workflow": "site-b27-native-validation",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "site-b27",
-        "site-b27-validation",
-        "thought-experiments-b27"
-      ],
-      "run_hours_utc": [
-        0,
-        6,
-        12,
-        18
-      ],
+      "aliases": ["site-b27", "site-b27-validation", "thought-experiments-b27"],
+      "run_hours_utc": [0, 6, 12, 18],
       "inputs": {},
       "status": "sovereign-local-b27-validation-no-github-token-no-remote-checkout-no-artifact-custody"
     },
@@ -44,36 +26,8 @@
       "workflow": "marketplace-coinbase-local-observer",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "site-marketplace-coinbase",
-        "marketplace-coinbase-observer"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["site-marketplace-coinbase", "marketplace-coinbase-observer"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "status": "sovereign-local-hourly-observer-no-github-token-no-remote-checkout"
     },
@@ -82,36 +36,8 @@
       "workflow": "marketplace-coinbase-local-projection-import",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "site-marketplace-projection",
-        "marketplace-coinbase-projection"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["site-marketplace-projection", "marketplace-coinbase-projection"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "status": "sovereign-local-hourly-projection-import-no-github-token-no-remote-fetch"
     },
@@ -120,36 +46,8 @@
       "workflow": "child-safety-public-deployment-observer",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "site-child-safety",
-        "child-safety-public-observer"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["site-child-safety", "child-safety-public-observer"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "status": "sovereign-local-hourly-public-route-observer-no-github-token-no-artifact-custody"
     },
@@ -158,14 +56,8 @@
       "workflow": "executive-rhetoric-ledger-local-sync",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "site-erl-sync",
-        "executive-rhetoric-ledger-sync",
-        "erl-sync"
-      ],
-      "run_hours_utc": [
-        14
-      ],
+      "aliases": ["site-erl-sync", "executive-rhetoric-ledger-sync", "erl-sync"],
+      "run_hours_utc": [14],
       "inputs": {},
       "canonical_owner": "StegVerse-Labs/StegVerse-Healer#39",
       "source_repository": "StegVerse-Labs/Executive_Rhetoric_Ledger",
@@ -179,37 +71,8 @@
       "workflow": "heartbeat-response-sovereign-carrier",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "site-heartbeat-response",
-        "heartbeat-response-watchdog",
-        "heartbeat-response-collector"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["site-heartbeat-response", "heartbeat-response-watchdog", "heartbeat-response-collector"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "canonical_owner": "StegVerse-Labs/Site#234",
       "migration_issue": "StegVerse-Labs/Site#411",
@@ -220,37 +83,8 @@
       "workflow": "stegfin-public-wallet-transport-observer",
       "ref": "main",
       "enabled": false,
-      "aliases": [
-        "site-stegfin-publication",
-        "stegfin-wallet-publication",
-        "stegfin-public-wallet-transport"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["site-stegfin-publication", "stegfin-wallet-publication", "stegfin-public-wallet-transport"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "canonical_owner": "StegVerse-Labs/Site#388",
       "canonical_surface": ".github/workflows/validate.yml + scripts/check_stegfin_public_wallet_transport.py",
@@ -262,17 +96,8 @@
       "workflow": "st018-local-task-manager",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "repo-standards",
-        "st018-local",
-        "st018-task-manager"
-      ],
-      "run_hours_utc": [
-        0,
-        6,
-        12,
-        18
-      ],
+      "aliases": ["repo-standards", "st018-local", "st018-task-manager"],
+      "run_hours_utc": [0, 6, 12, 18],
       "inputs": {},
       "status": "sovereign-local-st018-task-manager-no-github-token-no-remote-checkout"
     },
@@ -281,20 +106,9 @@
       "workflow": "scw_orchestrator.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "scw"
-      ],
-      "run_hours_utc": [
-        0,
-        6,
-        12,
-        18
-      ],
-      "inputs": {
-        "cmd": "org-scan",
-        "orgs": "StegVerse-Labs",
-        "dry_run": "true"
-      },
+      "aliases": ["scw"],
+      "run_hours_utc": [0, 6, 12, 18],
+      "inputs": {"cmd": "org-scan", "orgs": "StegVerse-Labs", "dry_run": "true"},
       "status": "sovereign-local-handler-bound-no-github-token"
     },
     {
@@ -302,36 +116,8 @@
       "workflow": "uptime.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "scw-uptime",
-        "uptime"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["scw-uptime", "uptime"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "status": "sovereign-local-hourly-handler-bound"
     },
@@ -340,13 +126,8 @@
       "workflow": "tv_self_heal.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "tv",
-        "tv-self-heal"
-      ],
-      "run_hours_utc": [
-        6
-      ],
+      "aliases": ["tv", "tv-self-heal"],
+      "run_hours_utc": [6],
       "inputs": {},
       "status": "sovereign-local-handler-bound-tvc-execution-grant-required"
     },
@@ -354,9 +135,7 @@
       "repo": "StegVerse-Labs/CosDen",
       "enabled": false,
       "audit_only": true,
-      "aliases": [
-        "cosden"
-      ],
+      "aliases": ["cosden"],
       "canonical_owner": "StegVerse-Labs/StegDB",
       "canonical_path": "canonical/cosden",
       "handoff": "docs/COSDEN_MIRROR_HANDOFF.md",
@@ -367,16 +146,8 @@
       "workflow": "continuity.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "continuity",
-        "continuity-guardian"
-      ],
-      "run_hours_utc": [
-        0,
-        6,
-        12,
-        18
-      ],
+      "aliases": ["continuity", "continuity-guardian"],
+      "run_hours_utc": [0, 6, 12, 18],
       "inputs": {},
       "status": "sovereign-local-handler-bound-no-github-token"
     },
@@ -385,13 +156,8 @@
       "workflow": "quiet_enforcer.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "quiet-enforcer",
-        "schedule-audit"
-      ],
-      "run_hours_utc": [
-        3
-      ],
+      "aliases": ["quiet-enforcer", "schedule-audit"],
+      "run_hours_utc": [3],
       "inputs": {},
       "status": "sovereign-local-handler-bound-no-github-token"
     },
@@ -400,36 +166,8 @@
       "workflow": "stegdeploy-publication-relay.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "stegdeploy-relay",
-        "publication-relay"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["stegdeploy-relay", "publication-relay"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "status": "sovereign-local-handler-bound-local-image-proof-required"
     },
@@ -438,37 +176,8 @@
       "workflow": "coinbase-stegdeploy-sovereign-gateway",
       "ref": "main",
       "enabled": true,
-      "aliases": [
-        "coinbase-gateway",
-        "coinbase-stegdeploy",
-        "skap-gateway"
-      ],
-      "run_hours_utc": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23
-      ],
+      "aliases": ["coinbase-gateway", "coinbase-stegdeploy", "skap-gateway"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "inputs": {},
       "canonical_owner": "StegVerse-Labs/TVC#119",
       "handoff": "docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md",

--- a/data/orchestrator_targets.json
+++ b/data/orchestrator_targets.json
@@ -6,9 +6,18 @@
       "workflow": "site-task-runner.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": ["site"],
-      "run_hours_utc": [0, 6, 12, 18],
-      "inputs": {"task": "all-local"},
+      "aliases": [
+        "site"
+      ],
+      "run_hours_utc": [
+        0,
+        6,
+        12,
+        18
+      ],
+      "inputs": {
+        "task": "all-local"
+      },
       "status": "sovereign-local-handler-bound"
     },
     {
@@ -16,8 +25,17 @@
       "workflow": "site-b27-native-validation",
       "ref": "main",
       "enabled": true,
-      "aliases": ["site-b27", "site-b27-validation", "thought-experiments-b27"],
-      "run_hours_utc": [0, 6, 12, 18],
+      "aliases": [
+        "site-b27",
+        "site-b27-validation",
+        "thought-experiments-b27"
+      ],
+      "run_hours_utc": [
+        0,
+        6,
+        12,
+        18
+      ],
       "inputs": {},
       "status": "sovereign-local-b27-validation-no-github-token-no-remote-checkout-no-artifact-custody"
     },
@@ -26,8 +44,36 @@
       "workflow": "marketplace-coinbase-local-observer",
       "ref": "main",
       "enabled": true,
-      "aliases": ["site-marketplace-coinbase", "marketplace-coinbase-observer"],
-      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "aliases": [
+        "site-marketplace-coinbase",
+        "marketplace-coinbase-observer"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
       "inputs": {},
       "status": "sovereign-local-hourly-observer-no-github-token-no-remote-checkout"
     },
@@ -36,8 +82,36 @@
       "workflow": "marketplace-coinbase-local-projection-import",
       "ref": "main",
       "enabled": true,
-      "aliases": ["site-marketplace-projection", "marketplace-coinbase-projection"],
-      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "aliases": [
+        "site-marketplace-projection",
+        "marketplace-coinbase-projection"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
       "inputs": {},
       "status": "sovereign-local-hourly-projection-import-no-github-token-no-remote-fetch"
     },
@@ -46,8 +120,36 @@
       "workflow": "child-safety-public-deployment-observer",
       "ref": "main",
       "enabled": true,
-      "aliases": ["site-child-safety", "child-safety-public-observer"],
-      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "aliases": [
+        "site-child-safety",
+        "child-safety-public-observer"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
       "inputs": {},
       "status": "sovereign-local-hourly-public-route-observer-no-github-token-no-artifact-custody"
     },
@@ -56,8 +158,14 @@
       "workflow": "executive-rhetoric-ledger-local-sync",
       "ref": "main",
       "enabled": true,
-      "aliases": ["site-erl-sync", "executive-rhetoric-ledger-sync", "erl-sync"],
-      "run_hours_utc": [14],
+      "aliases": [
+        "site-erl-sync",
+        "executive-rhetoric-ledger-sync",
+        "erl-sync"
+      ],
+      "run_hours_utc": [
+        14
+      ],
       "inputs": {},
       "canonical_owner": "StegVerse-Labs/StegVerse-Healer#39",
       "source_repository": "StegVerse-Labs/Executive_Rhetoric_Ledger",
@@ -71,8 +179,37 @@
       "workflow": "heartbeat-response-sovereign-carrier",
       "ref": "main",
       "enabled": true,
-      "aliases": ["site-heartbeat-response", "heartbeat-response-watchdog", "heartbeat-response-collector"],
-      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "aliases": [
+        "site-heartbeat-response",
+        "heartbeat-response-watchdog",
+        "heartbeat-response-collector"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
       "inputs": {},
       "canonical_owner": "StegVerse-Labs/Site#234",
       "migration_issue": "StegVerse-Labs/Site#411",
@@ -83,8 +220,37 @@
       "workflow": "stegfin-public-wallet-transport-observer",
       "ref": "main",
       "enabled": false,
-      "aliases": ["site-stegfin-publication", "stegfin-wallet-publication", "stegfin-public-wallet-transport"],
-      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "aliases": [
+        "site-stegfin-publication",
+        "stegfin-wallet-publication",
+        "stegfin-public-wallet-transport"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
       "inputs": {},
       "canonical_owner": "StegVerse-Labs/Site#388",
       "canonical_surface": ".github/workflows/validate.yml + scripts/check_stegfin_public_wallet_transport.py",
@@ -96,8 +262,17 @@
       "workflow": "st018-local-task-manager",
       "ref": "main",
       "enabled": true,
-      "aliases": ["repo-standards", "st018-local", "st018-task-manager"],
-      "run_hours_utc": [0, 6, 12, 18],
+      "aliases": [
+        "repo-standards",
+        "st018-local",
+        "st018-task-manager"
+      ],
+      "run_hours_utc": [
+        0,
+        6,
+        12,
+        18
+      ],
       "inputs": {},
       "status": "sovereign-local-st018-task-manager-no-github-token-no-remote-checkout"
     },
@@ -106,9 +281,20 @@
       "workflow": "scw_orchestrator.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": ["scw"],
-      "run_hours_utc": [0, 6, 12, 18],
-      "inputs": {"cmd": "org-scan", "orgs": "StegVerse-Labs", "dry_run": "true"},
+      "aliases": [
+        "scw"
+      ],
+      "run_hours_utc": [
+        0,
+        6,
+        12,
+        18
+      ],
+      "inputs": {
+        "cmd": "org-scan",
+        "orgs": "StegVerse-Labs",
+        "dry_run": "true"
+      },
       "status": "sovereign-local-handler-bound-no-github-token"
     },
     {
@@ -116,8 +302,36 @@
       "workflow": "uptime.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": ["scw-uptime", "uptime"],
-      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "aliases": [
+        "scw-uptime",
+        "uptime"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
       "inputs": {},
       "status": "sovereign-local-hourly-handler-bound"
     },
@@ -126,8 +340,13 @@
       "workflow": "tv_self_heal.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": ["tv", "tv-self-heal"],
-      "run_hours_utc": [6],
+      "aliases": [
+        "tv",
+        "tv-self-heal"
+      ],
+      "run_hours_utc": [
+        6
+      ],
       "inputs": {},
       "status": "sovereign-local-handler-bound-tvc-execution-grant-required"
     },
@@ -135,7 +354,9 @@
       "repo": "StegVerse-Labs/CosDen",
       "enabled": false,
       "audit_only": true,
-      "aliases": ["cosden"],
+      "aliases": [
+        "cosden"
+      ],
       "canonical_owner": "StegVerse-Labs/StegDB",
       "canonical_path": "canonical/cosden",
       "handoff": "docs/COSDEN_MIRROR_HANDOFF.md",
@@ -146,8 +367,16 @@
       "workflow": "continuity.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": ["continuity", "continuity-guardian"],
-      "run_hours_utc": [0, 6, 12, 18],
+      "aliases": [
+        "continuity",
+        "continuity-guardian"
+      ],
+      "run_hours_utc": [
+        0,
+        6,
+        12,
+        18
+      ],
       "inputs": {},
       "status": "sovereign-local-handler-bound-no-github-token"
     },
@@ -156,8 +385,13 @@
       "workflow": "quiet_enforcer.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": ["quiet-enforcer", "schedule-audit"],
-      "run_hours_utc": [3],
+      "aliases": [
+        "quiet-enforcer",
+        "schedule-audit"
+      ],
+      "run_hours_utc": [
+        3
+      ],
       "inputs": {},
       "status": "sovereign-local-handler-bound-no-github-token"
     },
@@ -166,10 +400,79 @@
       "workflow": "stegdeploy-publication-relay.yml",
       "ref": "main",
       "enabled": true,
-      "aliases": ["stegdeploy-relay", "publication-relay"],
-      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "aliases": [
+        "stegdeploy-relay",
+        "publication-relay"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
       "inputs": {},
       "status": "sovereign-local-handler-bound-local-image-proof-required"
+    },
+    {
+      "repo": "StegVerse-org/LLM-adapter",
+      "workflow": "coinbase-stegdeploy-sovereign-gateway",
+      "ref": "main",
+      "enabled": true,
+      "aliases": [
+        "coinbase-gateway",
+        "coinbase-stegdeploy",
+        "skap-gateway"
+      ],
+      "run_hours_utc": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
+      "inputs": {},
+      "canonical_owner": "StegVerse-Labs/TVC#119",
+      "handoff": "docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md",
+      "status": "sovereign-local-hourly-stegdeploy-gateway-no-github-token-no-provider-authority"
     }
   ]
 }

--- a/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
+++ b/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
@@ -1,0 +1,96 @@
+# Coinbase StegDeploy Sovereign Gateway Activation Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/StegVerse-Healer`
+Canonical upstream source: `StegVerse-org/LLM-adapter`
+Canonical downstream owner: `StegVerse-Labs/TVC#119`
+
+## Goal
+
+Materialize and verify the already-merged Coinbase SKAP readiness/ingress routes on the existing sovereign StegDeploy runtime carrier without creating a second scheduler, second heartbeat, second gateway, provider credential path, or third-party production dependency.
+
+## Authority
+
+```text
+credential_authority: TV/TVC
+github_token_runtime_authority: NONE
+render_role: FALLBACK_ONLY
+healer_role: bounded sovereign execution carrier
+heartbeat_authority_effect: NONE
+gateway_credential_value_access: false
+gateway_decryption_authority: false
+gateway_execution_authority: NONE
+provider_operation_authority: NONE
+```
+
+The handler may consume only an already-local LLM-adapter source tree and a non-secret TVC no-value decision receipt for role `service_gateway_coinbase_skap_ciphertext_intake`. It must never fabricate that receipt.
+
+## Canonical source already complete
+
+LLM-adapter source has already merged:
+
+- deployed-entrypoint Coinbase readiness/ingress repair: PR #204 / merge `244902d475c12ee6bff7dd67e4dfacb4e2357ca7`
+- StegDeploy sovereign primary-runtime binding: PR #205 / merge `0ec44419ada49147feb1866abfa6fe4fb4d0bbb2`
+- Render compatibility deployment: optional fallback only; prior build failure from exhausted build minutes is not a production prerequisite.
+
+## This implementation lane
+
+Reuse `SHWP-HEALER-SOVEREIGN-SCHEDULER-001` and `app/sovereign_scheduler.py`.
+
+Install one fixed local target:
+
+```text
+repo: StegVerse-org/LLM-adapter
+workflow: coinbase-stegdeploy-sovereign-gateway
+handler: app/coinbase_stegdeploy_gateway.py
+scheduler: existing StegVerse-Healer sovereign scheduler
+```
+
+Expected local sequence:
+
+```text
+already-local LLM-adapter source
++ already-local non-secret TVC no-value decision receipt
+-> scripts/stegdeploy_bootstrap.py deploy
+-> local Docker Compose build with pull_policy=never
+-> GET http://127.0.0.1:8000/api/coinbase/skap/readiness
+-> require READY + TV/TVC + DEVICE_TO_KV + gateway_execution_authority=NONE
+-> secret-free local activation receipt
+```
+
+## Hard fail-closed boundaries
+
+- no GitHub token/PAT;
+- no provider credential/private key;
+- no network source clone/fetch/pull;
+- no Render/Vercel/Cloudflare authority;
+- no fabricated TVC decision;
+- no production-route claim from loopback readiness;
+- no SKAP Vault admission claim from Gateway staging readiness;
+- no Coinbase provider operation;
+- no order/trade/settlement authority.
+
+## Completion distinction
+
+Local sovereign Gateway readiness is not the production public HTTPS route.
+
+This lane becomes source-complete when the fixed handler, scheduler binding, target registration, tests, and this handoff are merged and validated.
+
+Actual runtime remains open until a real sovereign scheduler execution produces a local Gateway readiness receipt. Public route observation remains a separate downstream predicate owned by the Coinbase/Site/TVC activation chain.
+
+## Downstream chain
+
+```text
+real sovereign Gateway local readiness
+-> production HTTPS route observation
+-> TVC current P-256 recipient liveness / READY_FOR_OWNER_INGRESS
+-> current-iPhone WebAuthn/StegID + browser-local sealing
+-> DEVICE->KV
+-> KV->SKAP_VAULT
+-> Coinbase endpoint/session/grant/capability/fees
+-> StegFin #84 explicit approval
+-> max-$10 bounded maker proof
+-> settlement/reconciliation/repeat loop
+```
+
+User action required: NONE until READY_FOR_OWNER_INGRESS plus production public route are genuinely observed.

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -250,3 +250,27 @@ Workflow hygiene for `StegVerse-Labs/.github` continues under Healer #34 from th
 Site cost continuation remains Site #268. The VA Claims Guide lane is already released and must not be recreated. Current Site dependencies include the merged-but-not-task-observed VA governed-surface observer, Thought Experiments B27, the active StegFin `validate.yml` publication claim, and eventual retirement of the legacy ERL GitHub carrier only after a real sovereign scheduler receipt.
 
 Ordinary scheduler activation belongs to `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`; broader Site workflow/token remediation remains at Site #268. Future work must reuse established Healer handlers/scheduler rather than create a second scheduler/heartbeat.
+
+
+## Coinbase StegDeploy sovereign Gateway activation
+
+Canonical scoped handoff:
+
+`docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md`
+
+This lane reuses the existing `SHWP-HEALER-SOVEREIGN-SCHEDULER-001` rather than creating a second scheduler or heartbeat.
+
+Installed source on branch `feat/coinbase-stegdeploy-sovereign-gateway-20260827`:
+
+```text
+app/coinbase_stegdeploy_gateway.py
+app/sovereign_scheduler.py fixed handler binding
+data/orchestrator_targets.json::coinbase-stegdeploy-sovereign-gateway
+tests/test_coinbase_stegdeploy_gateway.py
+```
+
+The handler consumes only already-local `StegVerse-org/LLM-adapter` + `StegVerse-Labs/TVC` roots, refuses GitHub/provider credentials, requires an authentic non-secret TVC no-value decision receipt, invokes the already-merged local StegDeploy bootstrap, and requires canonical loopback Coinbase readiness with `gateway_execution_authority=NONE`.
+
+Source installation does not claim sovereign execution, public HTTPS reachability, TVC recipient liveness, owner ingress, provider capability, order execution, or settlement.
+
+Next runtime boundary: the existing sovereign scheduler executes this target on the admitted resident substrate. Missing local source, missing Docker/StegDeploy prerequisites, or missing TVC decision receipt must remain BLOCKED with no fabricated readiness.

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app import coinbase_stegdeploy_gateway as mod
+
+
+class CoinbaseStegDeployGatewayTests(unittest.TestCase):
+    def decision(self) -> dict:
+        return {
+            "role": "service_gateway_coinbase_skap_ciphertext_intake",
+            "admissible": True,
+            "binding_matched": True,
+            "allowed_keys": [],
+            "denied_keys": [],
+            "credential_values_available": False,
+            "decision_id": "sha256:test-decision",
+            "policy_hash": "sha256:test-policy",
+        }
+
+    def test_decision_requires_no_value_tvc_scope(self) -> None:
+        mod.validate_decision(self.decision())
+        bad = self.decision()
+        bad["credential_values_available"] = True
+        with self.assertRaisesRegex(mod.GatewayActivationError, "CREDENTIAL_VALUE_SCOPE"):
+            mod.validate_decision(bad)
+
+    def test_readiness_preserves_gateway_authority_boundary(self) -> None:
+        decision = self.decision()
+        payload = {
+            "state": "READY",
+            "service_id": "stegverse-service-gateway",
+            "adapter": "coinbase-skap-ciphertext-staging",
+            "transport_protocol": "InTr",
+            "completed_boundary": "DEVICE_TO_KV",
+            "credential_authority": "TV/TVC",
+            "gateway_credential_value_access": False,
+            "gateway_decryption_authority": False,
+            "gateway_execution_authority": "NONE",
+            "tvc_admission_completed": False,
+            "skap_vault_admission_completed": False,
+            "next_required_transition": "KV_SKAP_VAULT_INTERLOCK_ADMISSION",
+            "tvc_decision_id": decision["decision_id"],
+        }
+        mod.validate_readiness(payload, decision)
+        payload["gateway_execution_authority"] = "ORDER"
+        with self.assertRaisesRegex(mod.GatewayActivationError, "READINESS_BOUNDARY_INVALID"):
+            mod.validate_readiness(payload, decision)
+
+    def test_missing_decision_fails_closed_without_fabrication(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with self.assertRaisesRegex(mod.GatewayActivationError, "NOT_MATERIALIZED"):
+                mod.locate_decision(root)
+
+    def test_scheduler_target_is_registered_and_bounded(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        config = json.loads((root / "data/orchestrator_targets.json").read_text(encoding="utf-8"))
+        targets = [
+            row for row in config["targets"]
+            if row.get("repo") == "StegVerse-org/LLM-adapter"
+            and row.get("workflow") == "coinbase-stegdeploy-sovereign-gateway"
+        ]
+        self.assertEqual(len(targets), 1)
+        target = targets[0]
+        self.assertTrue(target["enabled"])
+        self.assertEqual(target["canonical_owner"], "StegVerse-Labs/TVC#119")
+        self.assertIn("no-provider-authority", target["status"])
+        scheduler = (root / "app/sovereign_scheduler.py").read_text(encoding="utf-8")
+        self.assertIn('workflow == "coinbase-stegdeploy-sovereign-gateway"', scheduler)
+        self.assertIn("execute_coinbase_gateway(all_roots_json)", scheduler)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the missing machine-owned Coinbase Gateway activation carrier to the existing sovereign Healer scheduler.

Changes:
- canonical scoped MIRROR_HANDOFF first;
- bounded local StegDeploy Gateway handler;
- exact existing scheduler target, no second scheduler/heartbeat;
- requires authentic non-secret TVC no-value decision receipt;
- refuses GitHub/provider credential environments;
- local build only, Render not required;
- verifies loopback /api/coinbase/skap/readiness;
- explicitly does not claim production public route, TVC liveness, owner ingress, provider operation, order, or settlement;
- deterministic boundary/registration tests.

Downstream production predicates remain open until actual sovereign execution and public HTTPS observation.