### PR TITLE
Verify canonical TVC Coinbase Gateway decision digest

### DIFF
--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -13,6 +14,7 @@ from typing import Any
 LLM_REPO = "StegVerse-org/LLM-adapter"
 TVC_REPO = "StegVerse-Labs/TVC"
 ROLE = "service_gateway_coinbase_skap_ciphertext_intake"
+DECISION_SCHEMA = "stegverse.tvc.coinbase_service_gateway_no_value_decision/v1"
 READINESS_URL = "http://127.0.0.1:8000/api/coinbase/skap/readiness"
 FORBIDDEN_ENV = (
     "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
@@ -29,6 +31,14 @@ DECISION_CANDIDATES = (
 
 class GatewayActivationError(ValueError):
     pass
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical(value)).hexdigest()
 
 
 def load_roots(raw_override: str | None = None) -> dict[str, Path]:
@@ -48,6 +58,15 @@ def load_roots(raw_override: str | None = None) -> dict[str, Path]:
 
 
 def validate_decision(receipt: dict[str, Any]) -> None:
+    if receipt.get("schema") != DECISION_SCHEMA:
+        raise GatewayActivationError("TVC_DECISION_SCHEMA_INVALID")
+    body = {k: v for k, v in receipt.items() if k != "receipt_digest"}
+    if receipt.get("receipt_digest") != digest(body):
+        raise GatewayActivationError("TVC_DECISION_RECEIPT_DIGEST_INVALID")
+    for field in ("policy_hash", "decision_id"):
+        value = receipt.get(field)
+        if not isinstance(value, str) or not value.startswith("sha256:") or len(value) != 71:
+            raise GatewayActivationError(f"TVC_DECISION_{field.upper()}_INVALID")
     if receipt.get("role") != ROLE:
         raise GatewayActivationError("TVC_DECISION_ROLE_INVALID")
     if receipt.get("admissible") is not True or receipt.get("binding_matched") is not True:

--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -41,6 +41,15 @@ def digest(value: Any) -> str:
     return "sha256:" + hashlib.sha256(canonical(value)).hexdigest()
 
 
+def valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and value.startswith("sha256:")
+        and len(value) == 71
+        and all(ch in "0123456789abcdef" for ch in value[7:])
+    )
+
+
 def load_roots(raw_override: str | None = None) -> dict[str, Path]:
     raw = (raw_override if raw_override is not None else os.getenv("STEGVERSE_REPO_ROOTS_JSON", "")).strip()
     if not raw:
@@ -65,7 +74,7 @@ def validate_decision(receipt: dict[str, Any]) -> None:
         raise GatewayActivationError("TVC_DECISION_RECEIPT_DIGEST_INVALID")
     for field in ("policy_hash", "decision_id"):
         value = receipt.get(field)
-        if not isinstance(value, str) or not value.startswith("sha256:") or len(value) != 71:
+        if not valid_sha256(value):
             raise GatewayActivationError(f"TVC_DECISION_{field.upper()}_INVALID")
     if receipt.get("role") != ROLE:
         raise GatewayActivationError("TVC_DECISION_ROLE_INVALID")

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -19,7 +19,7 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
             "denied_keys": [],
             "credential_values_available": False,
             "decision_id": "sha256:" + "d" * 64,
-            "policy_hash": "sha256:" + "p" * 64,
+            "policy_hash": "sha256:" + "a" * 64,
         }
         return {**body, "receipt_digest": mod.digest(body)}
 

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -10,22 +10,35 @@ from app import coinbase_stegdeploy_gateway as mod
 
 class CoinbaseStegDeployGatewayTests(unittest.TestCase):
     def decision(self) -> dict:
-        return {
+        body = {
+            "schema": "stegverse.tvc.coinbase_service_gateway_no_value_decision/v1",
             "role": "service_gateway_coinbase_skap_ciphertext_intake",
             "admissible": True,
             "binding_matched": True,
             "allowed_keys": [],
             "denied_keys": [],
             "credential_values_available": False,
-            "decision_id": "sha256:test-decision",
-            "policy_hash": "sha256:test-policy",
+            "decision_id": "sha256:" + "d" * 64,
+            "policy_hash": "sha256:" + "p" * 64,
         }
+        return {**body, "receipt_digest": mod.digest(body)}
+
+    def redigest(self, receipt: dict) -> None:
+        body = {k: v for k, v in receipt.items() if k != "receipt_digest"}
+        receipt["receipt_digest"] = mod.digest(body)
 
     def test_decision_requires_no_value_tvc_scope(self) -> None:
         mod.validate_decision(self.decision())
         bad = self.decision()
         bad["credential_values_available"] = True
+        self.redigest(bad)
         with self.assertRaisesRegex(mod.GatewayActivationError, "CREDENTIAL_VALUE_SCOPE"):
+            mod.validate_decision(bad)
+
+    def test_decision_tamper_is_rejected_before_runtime(self) -> None:
+        bad = self.decision()
+        bad["admissible"] = False
+        with self.assertRaisesRegex(mod.GatewayActivationError, "RECEIPT_DIGEST_INVALID"):
             mod.validate_decision(bad)
 
     def test_readiness_preserves_gateway_authority_boundary(self) -> None:


### PR DESCRIPTION
Hardens the already-merged sovereign Coinbase Gateway carrier before runtime execution.

- requires the canonical TVC no-value decision schema;
- verifies the decision receipt digest over canonical JSON;
- requires valid SHA-256 policy/decision bindings;
- preserves all no-value/no-provider authority checks;
- adds tamper rejection coverage.

No runtime, public-route, credential, provider, order, or settlement claim is introduced.