### PR TITLE
Wire Coinbase Gateway carrier to native StegDeploy TLS

### DIFF
--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -16,6 +17,10 @@ TVC_REPO = "StegVerse-Labs/TVC"
 ROLE = "service_gateway_coinbase_skap_ciphertext_intake"
 DECISION_SCHEMA = "stegverse.tvc.coinbase_service_gateway_no_value_decision/v1"
 READINESS_URL = "http://127.0.0.1:8000/api/coinbase/skap/readiness"
+TLS_CERT_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_CERT_FILE"
+TLS_KEY_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_KEY_FILE"
+TLS_BIND_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_BIND_ADDRESS"
+TLS_PORT_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_PORT"
 FORBIDDEN_ENV = (
     "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
     "GH_STEGVERSE_AI_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
@@ -47,6 +52,64 @@ def valid_sha256(value: Any) -> bool:
         and value.startswith("sha256:")
         and len(value) == 71
         and all(ch in "0123456789abcdef" for ch in value[7:])
+    )
+
+
+def resolve_tls_request() -> dict[str, Any] | None:
+    cert_raw = os.getenv(TLS_CERT_ENV, "").strip()
+    key_raw = os.getenv(TLS_KEY_ENV, "").strip()
+    if bool(cert_raw) != bool(key_raw):
+        raise GatewayActivationError("TLS_CERT_AND_KEY_LOCATORS_MUST_BE_PAIRED")
+    if not cert_raw:
+        return None
+
+    cert_file = Path(cert_raw).expanduser().resolve()
+    key_file = Path(key_raw).expanduser().resolve()
+    if not cert_file.is_file():
+        raise GatewayActivationError("TLS_CERT_FILE_NOT_MATERIALIZED")
+    if not key_file.is_file():
+        raise GatewayActivationError("TLS_KEY_FILE_NOT_MATERIALIZED")
+
+    bind_address = os.getenv(TLS_BIND_ENV, "0.0.0.0").strip() or "0.0.0.0"
+    try:
+        port = int(os.getenv(TLS_PORT_ENV, "443"))
+    except ValueError as exc:
+        raise GatewayActivationError("TLS_PORT_INVALID") from exc
+    if not (1 <= port <= 65535):
+        raise GatewayActivationError("TLS_PORT_INVALID")
+
+    return {
+        "cert_file": cert_file,
+        "key_file": key_file,
+        "bind_address": bind_address,
+        "port": port,
+    }
+
+
+def build_deploy_command(tls_request: dict[str, Any] | None) -> tuple[list[str], str, bool]:
+    if tls_request is None:
+        return (
+            [sys.executable, "scripts/stegdeploy_bootstrap.py", "deploy", "--health-url", "http://127.0.0.1:8000/health"],
+            READINESS_URL,
+            False,
+        )
+    port = int(tls_request["port"])
+    return (
+        [
+            sys.executable,
+            "scripts/stegdeploy_bootstrap.py",
+            "deploy-tls",
+            "--tls-cert-file",
+            str(tls_request["cert_file"]),
+            "--tls-key-file",
+            str(tls_request["key_file"]),
+            "--bind-address",
+            str(tls_request["bind_address"]),
+            "--port",
+            str(port),
+        ],
+        f"https://127.0.0.1:{port}/api/coinbase/skap/readiness",
+        True,
     )
 
 
@@ -152,12 +215,15 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
     if tvc_root is None:
         raise GatewayActivationError("TVC_LOCAL_REPOSITORY_NOT_MATERIALIZED")
 
-    required = (
+    tls_request = resolve_tls_request()
+    required = [
         llm_root / "scripts/stegdeploy_bootstrap.py",
         llm_root / "compose.stegdeploy.yaml",
         llm_root / "llm_adapter/deployed_gateway.py",
         llm_root / "llm_adapter/service_gateway_composed.py",
-    )
+    ]
+    if tls_request is not None:
+        required.append(llm_root / "compose.stegdeploy.tls.yaml")
     missing = [str(path.relative_to(llm_root)) for path in required if not path.is_file()]
     if missing:
         raise GatewayActivationError("LLM_ADAPTER_STEGDEPLOY_SOURCE_INCOMPLETE:" + ",".join(missing))
@@ -173,8 +239,9 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
     if head.returncode != 0 or len(source_head) != 40:
         raise GatewayActivationError("LLM_ADAPTER_SOURCE_HEAD_UNPROVEN")
 
+    deploy_command, readiness_url, tls_enabled = build_deploy_command(tls_request)
     deploy = subprocess.run(
-        [sys.executable, "scripts/stegdeploy_bootstrap.py", "deploy", "--health-url", "http://127.0.0.1:8000/health"],
+        deploy_command,
         cwd=llm_root, env=env, text=True, capture_output=True, check=False, timeout=900,
     )
     if deploy.returncode != 0:
@@ -190,11 +257,13 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
             "github_token_required": False,
             "provider_operation_started": False,
             "production_public_route_observed": False,
+            "tls_enabled": tls_enabled,
             "authority_effect": "NONE",
         }
 
     try:
-        with urllib.request.urlopen(READINESS_URL, timeout=5) as response:
+        context = ssl._create_unverified_context() if tls_enabled else None
+        with urllib.request.urlopen(readiness_url, timeout=5, context=context) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except Exception as exc:
         raise GatewayActivationError("LOCAL_COINBASE_READINESS_UNAVAILABLE:" + type(exc).__name__) from exc
@@ -205,21 +274,25 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
     return {
         "schema": "stegverse.healer.coinbase_stegdeploy_gateway_activation/v1",
         "state": "COMPLETE",
-        "outcome": "LOCAL_SOVEREIGN_COINBASE_GATEWAY_READY",
+        "outcome": "LOCAL_SOVEREIGN_COINBASE_GATEWAY_TLS_READY" if tls_enabled else "LOCAL_SOVEREIGN_COINBASE_GATEWAY_READY",
         "source_head": source_head,
         "decision_ref": str(decision_path),
         "decision_id": decision["decision_id"],
-        "readiness_url": READINESS_URL,
+        "readiness_url": readiness_url,
         "readiness": payload,
         "credential_authority": "TV/TVC",
         "credential_material_present": False,
         "github_token_required": False,
         "render_required": False,
+        "tls_enabled": tls_enabled,
+        "tls_locator_source": "TV_TVC_RUNTIME_FILE_PATHS" if tls_enabled else "NONE",
+        "tls_private_key_material_recorded": False,
+        "public_certificate_hostname_verified": False,
         "network_source_fetch_performed": False,
         "provider_operation_started": False,
         "may_authorize_order": False,
         "production_public_route_observed": False,
-        "authority_effect": "LOCAL_RUNTIME_OBSERVATION_ONLY",
+        "authority_effect": "LOCAL_TLS_RUNTIME_OBSERVATION_ONLY" if tls_enabled else "LOCAL_RUNTIME_OBSERVATION_ONLY",
     }
 
 

--- a/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
+++ b/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
@@ -161,3 +161,48 @@ TVC advertised-route observer PR #179:
 ```
 
 After a real local StegDeploy execution, the node itself can advertise Coinbase routes and TVC can consume them without an out-of-band hostname. Actual public TLS ingress/reachability remains separate and unobserved.
+
+
+## Native TLS runtime locator integration — 2026-08-27
+
+Upstream native TLS source is now merged and hosted-validated:
+
+```text
+StegVerse-org/LLM-adapter PR #209
+merge: 10a6f6247771b2a85b07f5f19810403c3acde513
+Coinbase SKAP Service Gateway Validation: 33121152939 SUCCESS
+global validate: 33121152794 SUCCESS
+TLS termination: UVICORN_NATIVE
+reverse proxy required: false
+Render/Cloudflare required: false
+```
+
+The existing Healer target now accepts optional path-only runtime locators:
+
+```text
+STEGVERSE_SERVICE_GATEWAY_TLS_CERT_FILE
+STEGVERSE_SERVICE_GATEWAY_TLS_KEY_FILE
+STEGVERSE_SERVICE_GATEWAY_TLS_BIND_ADDRESS
+STEGVERSE_SERVICE_GATEWAY_TLS_PORT
+```
+
+These variables are locators/configuration only; certificate/private-key bytes are not read into the Healer receipt and are not copied into the child environment as secret values. Certificate/key locators must be paired and materialized locally before the TLS attempt.
+
+Behavior:
+
+```text
+no TLS locators
+-> existing local HTTP StegDeploy readiness only
+-> production_public_route_observed=false
+
+paired TV/TVC TLS locators
+-> existing LLM-adapter deploy-tls bootstrap
+-> native Uvicorn TLS
+-> local HTTPS readiness
+-> production_public_route_observed=false
+-> public_certificate_hostname_verified=false
+```
+
+A local TLS-ready receipt remains insufficient for production route activation. TVC must still independently observe the advertised HTTPS node/readiness route with normal hostname/certificate verification.
+
+No user-operated second machine and no manual shell step are introduced.

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -69,6 +69,61 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
             with self.assertRaisesRegex(mod.GatewayActivationError, "NOT_MATERIALIZED"):
                 mod.locate_decision(root)
 
+
+    def test_tls_locators_are_path_only_and_must_be_paired(self) -> None:
+        import os
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cert = root / "cert.pem"
+            key = root / "key.pem"
+            cert.write_text("cert", encoding="utf-8")
+            key.write_text("key", encoding="utf-8")
+
+            old = dict(os.environ)
+            try:
+                os.environ[mod.TLS_CERT_ENV] = str(cert)
+                os.environ.pop(mod.TLS_KEY_ENV, None)
+                with self.assertRaisesRegex(mod.GatewayActivationError, "MUST_BE_PAIRED"):
+                    mod.resolve_tls_request()
+
+                os.environ[mod.TLS_KEY_ENV] = str(key)
+                os.environ[mod.TLS_BIND_ENV] = "0.0.0.0"
+                os.environ[mod.TLS_PORT_ENV] = "443"
+                request = mod.resolve_tls_request()
+                self.assertIsNotNone(request)
+                self.assertEqual(request["cert_file"], cert.resolve())
+                self.assertEqual(request["key_file"], key.resolve())
+                self.assertEqual(request["bind_address"], "0.0.0.0")
+                self.assertEqual(request["port"], 443)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_tls_deploy_command_uses_existing_bootstrap_without_secret_values(self) -> None:
+        request = {
+            "cert_file": Path("/runtime/tvc/gateway-cert.pem"),
+            "key_file": Path("/runtime/tvc/gateway-key.pem"),
+            "bind_address": "0.0.0.0",
+            "port": 443,
+        }
+        command, readiness_url, tls_enabled = mod.build_deploy_command(request)
+        self.assertTrue(tls_enabled)
+        self.assertIn("deploy-tls", command)
+        self.assertIn("/runtime/tvc/gateway-cert.pem", command)
+        self.assertIn("/runtime/tvc/gateway-key.pem", command)
+        self.assertIn("0.0.0.0", command)
+        self.assertIn("443", command)
+        self.assertEqual(readiness_url, "https://127.0.0.1:443/api/coinbase/skap/readiness")
+        self.assertNotIn("PRIVATE KEY", " ".join(command))
+        self.assertNotIn("BEGIN CERTIFICATE", " ".join(command))
+
+    def test_http_mode_remains_local_and_non_public(self) -> None:
+        command, readiness_url, tls_enabled = mod.build_deploy_command(None)
+        self.assertFalse(tls_enabled)
+        self.assertIn("deploy", command)
+        self.assertEqual(readiness_url, mod.READINESS_URL)
+        self.assertTrue(readiness_url.startswith("http://127.0.0.1:"))
+
     def test_scheduler_target_is_registered_and_bounded(self) -> None:
         root = Path(__file__).resolve().parents[1]
         config = json.loads((root / "data/orchestrator_targets.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
Extends the existing sovereign Coinbase Gateway target to consume path-only TV/TVC TLS runtime locators after LLM-adapter PR #209 merged native Uvicorn TLS.

- no new scheduler or heartbeat;
- no certificate/private-key bytes in repo, child env, or receipts;
- cert/key locators must be paired and materialized locally;
- no TLS locators preserves existing loopback HTTP readiness mode;
- paired locators invoke the existing deploy-tls bootstrap;
- local TLS readiness still records production_public_route_observed=false and public_certificate_hostname_verified=false;
- independent TVC HTTPS observation remains required.

Upstream TLS merge: 10a6f6247771b2a85b07f5f19810403c3acde513.