### PR TITLE
Discover TVC Gateway TLS adoption receipt automatically

### DIFF
--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -159,12 +159,8 @@ def resolve_tls_request() -> dict[str, Any] | None:
 
     bind_address, port = _tls_bind_port()
     if cert_raw:
-        cert_file = Path(cert_raw).expanduser().resolve()
-        key_file = Path(key_raw).expanduser().resolve()
-        if not cert_file.is_file():
-            raise GatewayActivationError("TLS_CERT_FILE_NOT_MATERIALIZED")
-        if not key_file.is_file():
-            raise GatewayActivationError("TLS_KEY_FILE_NOT_MATERIALIZED")
+        cert_file = _validate_tvc_tls_locator(cert_raw, "CERT")
+        key_file = _validate_tvc_tls_locator(key_raw, "KEY")
         return {
             "cert_file": cert_file,
             "key_file": key_file,

--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -21,6 +21,10 @@ TLS_CERT_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_CERT_FILE"
 TLS_KEY_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_KEY_FILE"
 TLS_BIND_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_BIND_ADDRESS"
 TLS_PORT_ENV = "STEGVERSE_SERVICE_GATEWAY_TLS_PORT"
+TLS_ADOPTION_RECEIPT_ENV = "STEGVERSE_TVC_SERVICE_GATEWAY_TLS_ADOPTION_RECEIPT"
+TLS_ADOPTION_RECEIPT_DEFAULT = Path("/var/lib/stegverse/tvc/service-gateway-tls/latest.json")
+TVC_TLS_CREDENTIAL_ROOT = Path("/run/stegverse/tv-tvc-credentials")
+TLS_ADOPTION_SCHEMA = "stegverse.tvc.service_gateway_tls_material_adoption/v1"
 FORBIDDEN_ENV = (
     "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
     "GH_STEGVERSE_AI_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
@@ -55,21 +59,7 @@ def valid_sha256(value: Any) -> bool:
     )
 
 
-def resolve_tls_request() -> dict[str, Any] | None:
-    cert_raw = os.getenv(TLS_CERT_ENV, "").strip()
-    key_raw = os.getenv(TLS_KEY_ENV, "").strip()
-    if bool(cert_raw) != bool(key_raw):
-        raise GatewayActivationError("TLS_CERT_AND_KEY_LOCATORS_MUST_BE_PAIRED")
-    if not cert_raw:
-        return None
-
-    cert_file = Path(cert_raw).expanduser().resolve()
-    key_file = Path(key_raw).expanduser().resolve()
-    if not cert_file.is_file():
-        raise GatewayActivationError("TLS_CERT_FILE_NOT_MATERIALIZED")
-    if not key_file.is_file():
-        raise GatewayActivationError("TLS_KEY_FILE_NOT_MATERIALIZED")
-
+def _tls_bind_port() -> tuple[str, int]:
     bind_address = os.getenv(TLS_BIND_ENV, "0.0.0.0").strip() or "0.0.0.0"
     try:
         port = int(os.getenv(TLS_PORT_ENV, "443"))
@@ -77,14 +67,126 @@ def resolve_tls_request() -> dict[str, Any] | None:
         raise GatewayActivationError("TLS_PORT_INVALID") from exc
     if not (1 <= port <= 65535):
         raise GatewayActivationError("TLS_PORT_INVALID")
+    return bind_address, port
 
+
+def _validate_tvc_tls_locator(raw: Any, label: str) -> Path:
+    if not isinstance(raw, str) or not raw.strip():
+        raise GatewayActivationError(f"TVC_TLS_ADOPTION_{label}_LOCATOR_MISSING")
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        raise GatewayActivationError(f"TVC_TLS_ADOPTION_{label}_LOCATOR_NOT_ABSOLUTE")
+    if path.is_symlink():
+        raise GatewayActivationError(f"TVC_TLS_ADOPTION_{label}_LOCATOR_SYMLINK_FORBIDDEN")
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(TVC_TLS_CREDENTIAL_ROOT.resolve())
+    except ValueError as exc:
+        raise GatewayActivationError(f"TVC_TLS_ADOPTION_{label}_LOCATOR_OUTSIDE_TVC_ROOT") from exc
+    if not resolved.is_file():
+        raise GatewayActivationError(f"TVC_TLS_ADOPTION_{label}_FILE_NOT_MATERIALIZED")
+    return resolved
+
+
+def validate_tls_adoption_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    expected = {
+        "schema": TLS_ADOPTION_SCHEMA,
+        "state": "READY_FOR_STEGDEPLOY_TLS",
+        "credential_authority": "TV/TVC",
+        "gateway_credential_authority": "NONE",
+        "provider_operation_authority": "NONE",
+        "certificate_material_present": True,
+        "private_key_material_present": True,
+        "private_key_bytes_recorded": False,
+        "private_key_exported": False,
+        "credential_material_exported": False,
+        "certificate_pair_verified": True,
+        "certificate_hostname_verified": True,
+        "certificate_time_valid": True,
+        "certificate_acquisition_performed": False,
+        "certificate_issuance_performed": False,
+        "certificate_renewal_performed": False,
+        "certificate_revocation_performed": False,
+        "generalized_certificate_manager_created": False,
+        "github_token_required": False,
+        "production_public_route_observed": False,
+        "ready_for_owner_ingress": False,
+        "authority_effect": "TVC_RESIDENT_TLS_MATERIAL_ADOPTION_ONLY",
+    }
+    failed = [key for key, value in expected.items() if receipt.get(key) != value]
+    if failed:
+        raise GatewayActivationError("TVC_TLS_ADOPTION_BOUNDARY_INVALID:" + ",".join(sorted(failed)))
+    if not valid_sha256(receipt.get("certificate_sha256")):
+        raise GatewayActivationError("TVC_TLS_ADOPTION_CERTIFICATE_SHA256_INVALID")
+    body = {k: v for k, v in receipt.items() if k != "receipt_sha256"}
+    if receipt.get("receipt_sha256") != digest(body):
+        raise GatewayActivationError("TVC_TLS_ADOPTION_RECEIPT_DIGEST_INVALID")
+    hostname = receipt.get("hostname")
+    if not isinstance(hostname, str) or not hostname or "/" in hostname or ":" in hostname:
+        raise GatewayActivationError("TVC_TLS_ADOPTION_HOSTNAME_INVALID")
+    cert_file = _validate_tvc_tls_locator(receipt.get("certificate_file_locator"), "CERT")
+    key_file = _validate_tvc_tls_locator(receipt.get("private_key_file_locator"), "KEY")
     return {
         "cert_file": cert_file,
         "key_file": key_file,
-        "bind_address": bind_address,
-        "port": port,
+        "hostname": hostname,
+        "certificate_sha256": receipt["certificate_sha256"],
+        "receipt_sha256": receipt["receipt_sha256"],
     }
 
+
+def locate_tls_adoption_receipt() -> tuple[Path, dict[str, Any]] | None:
+    explicit = os.getenv(TLS_ADOPTION_RECEIPT_ENV, "").strip()
+    path = Path(explicit).expanduser().resolve() if explicit else TLS_ADOPTION_RECEIPT_DEFAULT
+    if not path.is_file():
+        if explicit:
+            raise GatewayActivationError("TVC_TLS_ADOPTION_RECEIPT_NOT_MATERIALIZED")
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise GatewayActivationError("TVC_TLS_ADOPTION_RECEIPT_UNREADABLE") from exc
+    if not isinstance(value, dict):
+        raise GatewayActivationError("TVC_TLS_ADOPTION_RECEIPT_OBJECT_REQUIRED")
+    return path, value
+
+
+def resolve_tls_request() -> dict[str, Any] | None:
+    cert_raw = os.getenv(TLS_CERT_ENV, "").strip()
+    key_raw = os.getenv(TLS_KEY_ENV, "").strip()
+    if bool(cert_raw) != bool(key_raw):
+        raise GatewayActivationError("TLS_CERT_AND_KEY_LOCATORS_MUST_BE_PAIRED")
+
+    bind_address, port = _tls_bind_port()
+    if cert_raw:
+        cert_file = Path(cert_raw).expanduser().resolve()
+        key_file = Path(key_raw).expanduser().resolve()
+        if not cert_file.is_file():
+            raise GatewayActivationError("TLS_CERT_FILE_NOT_MATERIALIZED")
+        if not key_file.is_file():
+            raise GatewayActivationError("TLS_KEY_FILE_NOT_MATERIALIZED")
+        return {
+            "cert_file": cert_file,
+            "key_file": key_file,
+            "bind_address": bind_address,
+            "port": port,
+            "locator_source": "EXPLICIT_TV_TVC_RUNTIME_FILE_PATHS",
+            "adoption_receipt_sha256": None,
+        }
+
+    located = locate_tls_adoption_receipt()
+    if located is None:
+        return None
+    _path, receipt = located
+    adopted = validate_tls_adoption_receipt(receipt)
+    return {
+        "cert_file": adopted["cert_file"],
+        "key_file": adopted["key_file"],
+        "bind_address": bind_address,
+        "port": port,
+        "locator_source": "TVC_TLS_ADOPTION_RECEIPT",
+        "adoption_receipt_sha256": adopted["receipt_sha256"],
+    }
 
 def build_deploy_command(tls_request: dict[str, Any] | None) -> tuple[list[str], str, bool]:
     if tls_request is None:
@@ -285,7 +387,8 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
         "github_token_required": False,
         "render_required": False,
         "tls_enabled": tls_enabled,
-        "tls_locator_source": "TV_TVC_RUNTIME_FILE_PATHS" if tls_enabled else "NONE",
+        "tls_locator_source": str(tls_request.get("locator_source")) if tls_enabled and tls_request else "NONE",
+        "tls_adoption_receipt_sha256": tls_request.get("adoption_receipt_sha256") if tls_enabled and tls_request else None,
         "tls_private_key_material_recorded": False,
         "public_certificate_hostname_verified": False,
         "network_source_fetch_performed": False,

--- a/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
+++ b/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
@@ -235,3 +235,37 @@ public HTTPS route: NOT OBSERVED
 user action required: false
 heartbeat dependency: false
 ```
+
+
+## TVC TLS adoption receipt auto-discovery
+
+The upstream TVC lane now has a bounded, credential-model-approved adoption/validation step for already-materialized Service Gateway TLS files:
+
+```text
+StegVerse-Labs/TVC PR #202
+merge: 0ca30b7806d2a96d9a256a7cd9fa0702f718a5e2
+TVC Credential Model Consistency Validation: 33139239831 SUCCESS
+Coinbase Gateway Stage Drain Validation: 33139239828 SUCCESS
+receipt schema: stegverse.tvc.service_gateway_tls_material_adoption/v1
+default resident receipt: /var/lib/stegverse/tvc/service-gateway-tls/latest.json
+classification: CONSISTENT_TARGET_UNPROVEN_RUNTIME
+```
+
+Healer may now discover that same-host receipt automatically when explicit TLS path locators are absent. It requires the exact TVC schema/state/digest, TV/TVC credential authority, Gateway/provider authority NONE, verified certificate pair/hostname/time validity, all acquisition/issuance/renewal/revocation flags false, and both locators confined beneath the TV/TVC resident credential root.
+
+Resolution precedence:
+
+```text
+paired explicit TV/TVC path locators
+  -> bounded compatibility override
+
+else valid TVC resident TLS adoption receipt
+  -> automatic native-TLS locator discovery
+
+else
+  -> existing local HTTP readiness mode only
+```
+
+Healer reads no certificate/private-key bytes. The LLM-adapter native TLS bootstrap remains responsible for final pair/permissions verification immediately before local TLS execution.
+
+This source integration does not claim that an authentic TVC adoption receipt currently exists, that native TLS executed, or that a production public HTTPS route is observed.

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -90,7 +90,8 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
                 os.environ[mod.TLS_KEY_ENV] = str(key)
                 os.environ[mod.TLS_BIND_ENV] = "0.0.0.0"
                 os.environ[mod.TLS_PORT_ENV] = "443"
-                request = mod.resolve_tls_request()
+                with mock.patch.object(mod, "TVC_TLS_CREDENTIAL_ROOT", root):
+                    request = mod.resolve_tls_request()
                 self.assertIsNotNone(request)
                 self.assertEqual(request["cert_file"], cert.resolve())
                 self.assertEqual(request["key_file"], key.resolve())
@@ -215,13 +216,35 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
                 os.environ[mod.TLS_CERT_ENV] = str(cert)
                 os.environ[mod.TLS_KEY_ENV] = str(key)
                 os.environ[mod.TLS_ADOPTION_RECEIPT_ENV] = str(root / "missing-adoption.json")
-                request = mod.resolve_tls_request()
+                with mock.patch.object(mod, "TVC_TLS_CREDENTIAL_ROOT", root):
+                    request = mod.resolve_tls_request()
             finally:
                 os.environ.clear()
                 os.environ.update(old)
 
             self.assertEqual(request["locator_source"], "EXPLICIT_TV_TVC_RUNTIME_FILE_PATHS")
             self.assertIsNone(request["adoption_receipt_sha256"])
+
+    def test_explicit_tls_locator_outside_tvc_root_is_rejected(self) -> None:
+        import os
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            credential_root = root / "credentials"
+            credential_root.mkdir()
+            cert = root / "outside-cert.pem"
+            key = root / "outside-key.pem"
+            cert.write_text("cert", encoding="utf-8")
+            key.write_text("key", encoding="utf-8")
+            old = dict(os.environ)
+            try:
+                os.environ[mod.TLS_CERT_ENV] = str(cert)
+                os.environ[mod.TLS_KEY_ENV] = str(key)
+                with mock.patch.object(mod, "TVC_TLS_CREDENTIAL_ROOT", credential_root):
+                    with self.assertRaisesRegex(mod.GatewayActivationError, "OUTSIDE_TVC_ROOT"):
+                        mod.resolve_tls_request()
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
 
     def test_tls_deploy_command_uses_existing_bootstrap_without_secret_values(self) -> None:
         request = {

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 from app import coinbase_stegdeploy_gateway as mod
@@ -98,6 +99,129 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
             finally:
                 os.environ.clear()
                 os.environ.update(old)
+
+    def tls_adoption_receipt(self, cert: Path, key: Path) -> dict:
+        body = {
+            "schema": mod.TLS_ADOPTION_SCHEMA,
+            "state": "READY_FOR_STEGDEPLOY_TLS",
+            "hostname": "gateway.stegverse.org",
+            "certificate_sha256": "sha256:" + "c" * 64,
+            "certificate_not_before": "Aug 27 00:00:00 2026 GMT",
+            "certificate_not_after": "Aug 27 00:00:00 2027 GMT",
+            "certificate_hostname": "gateway.stegverse.org",
+            "certificate_file_locator": str(cert),
+            "private_key_file_locator": str(key),
+            "certificate_material_present": True,
+            "private_key_material_present": True,
+            "private_key_bytes_recorded": False,
+            "private_key_exported": False,
+            "credential_material_exported": False,
+            "certificate_pair_verified": True,
+            "certificate_hostname_verified": True,
+            "certificate_time_valid": True,
+            "certificate_acquisition_performed": False,
+            "certificate_issuance_performed": False,
+            "certificate_renewal_performed": False,
+            "certificate_revocation_performed": False,
+            "generalized_certificate_manager_created": False,
+            "credential_authority": "TV/TVC",
+            "gateway_credential_authority": "NONE",
+            "provider_operation_authority": "NONE",
+            "github_token_required": False,
+            "production_public_route_observed": False,
+            "ready_for_owner_ingress": False,
+            "authority_effect": "TVC_RESIDENT_TLS_MATERIAL_ADOPTION_ONLY",
+        }
+        return {**body, "receipt_sha256": mod.digest(body)}
+
+    def test_tls_auto_discovers_valid_tvc_adoption_receipt(self) -> None:
+        import os
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            credential_root = root / "credentials"
+            credential_root.mkdir()
+            cert = credential_root / "cert.pem"
+            key = credential_root / "key.pem"
+            cert.write_text("cert", encoding="utf-8")
+            key.write_text("key", encoding="utf-8")
+            receipt_path = root / "adoption.json"
+            receipt = self.tls_adoption_receipt(cert, key)
+            receipt_path.write_text(json.dumps(receipt) + "\n", encoding="utf-8")
+
+            old = dict(os.environ)
+            try:
+                os.environ.pop(mod.TLS_CERT_ENV, None)
+                os.environ.pop(mod.TLS_KEY_ENV, None)
+                os.environ[mod.TLS_ADOPTION_RECEIPT_ENV] = str(receipt_path)
+                with mock.patch.object(mod, "TVC_TLS_CREDENTIAL_ROOT", credential_root):
+                    request = mod.resolve_tls_request()
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+            self.assertIsNotNone(request)
+            self.assertEqual(request["cert_file"], cert.resolve())
+            self.assertEqual(request["key_file"], key.resolve())
+            self.assertEqual(request["locator_source"], "TVC_TLS_ADOPTION_RECEIPT")
+            self.assertEqual(request["adoption_receipt_sha256"], receipt["receipt_sha256"])
+            self.assertEqual(request["port"], 443)
+
+    def test_tls_adoption_receipt_tamper_or_issuance_claim_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            credential_root = root / "credentials"
+            credential_root.mkdir()
+            cert = credential_root / "cert.pem"
+            key = credential_root / "key.pem"
+            cert.write_text("cert", encoding="utf-8")
+            key.write_text("key", encoding="utf-8")
+            with mock.patch.object(mod, "TVC_TLS_CREDENTIAL_ROOT", credential_root):
+                tampered = self.tls_adoption_receipt(cert, key)
+                tampered["hostname"] = "evil.example"
+                with self.assertRaisesRegex(mod.GatewayActivationError, "DIGEST_INVALID"):
+                    mod.validate_tls_adoption_receipt(tampered)
+
+                issuance = self.tls_adoption_receipt(cert, key)
+                issuance["certificate_issuance_performed"] = True
+                body = {k: v for k, v in issuance.items() if k != "receipt_sha256"}
+                issuance["receipt_sha256"] = mod.digest(body)
+                with self.assertRaisesRegex(mod.GatewayActivationError, "BOUNDARY_INVALID"):
+                    mod.validate_tls_adoption_receipt(issuance)
+
+    def test_tls_adoption_locator_must_remain_inside_tvc_credential_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            credential_root = root / "credentials"
+            credential_root.mkdir()
+            cert = credential_root / "cert.pem"
+            cert.write_text("cert", encoding="utf-8")
+            outside = root / "outside-key.pem"
+            outside.write_text("key", encoding="utf-8")
+            receipt = self.tls_adoption_receipt(cert, outside)
+            with mock.patch.object(mod, "TVC_TLS_CREDENTIAL_ROOT", credential_root):
+                with self.assertRaisesRegex(mod.GatewayActivationError, "OUTSIDE_TVC_ROOT"):
+                    mod.validate_tls_adoption_receipt(receipt)
+
+    def test_explicit_tls_locators_override_adoption_receipt_discovery(self) -> None:
+        import os
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cert = root / "explicit-cert.pem"
+            key = root / "explicit-key.pem"
+            cert.write_text("cert", encoding="utf-8")
+            key.write_text("key", encoding="utf-8")
+            old = dict(os.environ)
+            try:
+                os.environ[mod.TLS_CERT_ENV] = str(cert)
+                os.environ[mod.TLS_KEY_ENV] = str(key)
+                os.environ[mod.TLS_ADOPTION_RECEIPT_ENV] = str(root / "missing-adoption.json")
+                request = mod.resolve_tls_request()
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+            self.assertEqual(request["locator_source"], "EXPLICIT_TV_TVC_RUNTIME_FILE_PATHS")
+            self.assertIsNone(request["adoption_receipt_sha256"])
 
     def test_tls_deploy_command_uses_existing_bootstrap_without_secret_values(self) -> None:
         request = {


### PR DESCRIPTION
Removes the remaining manual TLS-locator mapping seam from the existing Coinbase StegDeploy Gateway carrier.

When paired explicit TV/TVC TLS locators are absent, the handler now checks the canonical same-host TVC adoption receipt at /var/lib/stegverse/tvc/service-gateway-tls/latest.json (or an explicit non-secret receipt path override).

It requires:
- exact TVC adoption schema/state/digest;
- TV/TVC credential authority;
- Gateway/provider authority NONE;
- pair/hostname/time-validity flags true;
- acquisition/issuance/renewal/revocation/generalized-manager flags false;
- private-key export/recording false;
- production route and owner-ingress flags false;
- certificate/key locators confined under /run/stegverse/tv-tvc-credentials and locally materialized.

Explicit paired path locators remain a compatibility override. Missing adoption evidence still falls back to local non-public HTTP readiness; no public route is claimed.

Upstream TVC adoption source: PR #202 / merge 0ca30b7806d2a96d9a256a7cd9fa0702f718a5e2 / validations 33139239831 and 33139239828 SUCCESS.