### PR TITLE
Adopt host-native Service Gateway in sovereign activation target

### DIFF
--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -25,6 +25,9 @@ TLS_ADOPTION_RECEIPT_ENV = "STEGVERSE_TVC_SERVICE_GATEWAY_TLS_ADOPTION_RECEIPT"
 TLS_ADOPTION_RECEIPT_DEFAULT = Path("/var/lib/stegverse/tvc/service-gateway-tls/latest.json")
 TVC_TLS_CREDENTIAL_ROOT = Path("/run/stegverse/tv-tvc-credentials")
 TLS_ADOPTION_SCHEMA = "stegverse.tvc.service_gateway_tls_material_adoption/v1"
+EVALUATOR_ENABLED_ENV = "STEGVERSE_EVALUATOR_INTR_ENABLED"
+EVALUATOR_UPSTREAM_ENV = "STEGVERSE_EVALUATOR_INTR_UPSTREAM"
+EVALUATOR_LOOPBACK_UPSTREAM = "http://127.0.0.1:8765/intr/evaluator"
 FORBIDDEN_ENV = (
     "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
     "GH_STEGVERSE_AI_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
@@ -184,10 +187,29 @@ def resolve_tls_request() -> dict[str, Any] | None:
         "adoption_receipt_sha256": adopted["receipt_sha256"],
     }
 
+def evaluator_runtime_config() -> dict[str, Any]:
+    raw = os.getenv(EVALUATOR_ENABLED_ENV, "false").strip().lower()
+    if raw not in {"true", "false", "1", "0", "yes", "no"}:
+        raise GatewayActivationError("EVALUATOR_INTR_ENABLED_INVALID")
+    enabled = raw in {"true", "1", "yes"}
+    upstream = os.getenv(EVALUATOR_UPSTREAM_ENV, EVALUATOR_LOOPBACK_UPSTREAM).strip()
+    if enabled and upstream != EVALUATOR_LOOPBACK_UPSTREAM:
+        raise GatewayActivationError("EVALUATOR_INTR_UPSTREAM_NOT_CANONICAL_LOOPBACK")
+    return {"enabled": enabled, "upstream": upstream if enabled else ""}
+
+
 def build_deploy_command(tls_request: dict[str, Any] | None) -> tuple[list[str], str, bool]:
     if tls_request is None:
         return (
-            [sys.executable, "scripts/stegdeploy_bootstrap.py", "deploy", "--health-url", "http://127.0.0.1:8000/health"],
+            [
+                sys.executable,
+                "scripts/stegdeploy_native_gateway.py",
+                "start",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8000",
+            ],
             READINESS_URL,
             False,
         )
@@ -195,13 +217,9 @@ def build_deploy_command(tls_request: dict[str, Any] | None) -> tuple[list[str],
     return (
         [
             sys.executable,
-            "scripts/stegdeploy_bootstrap.py",
-            "deploy-tls",
-            "--tls-cert-file",
-            str(tls_request["cert_file"]),
-            "--tls-key-file",
-            str(tls_request["key_file"]),
-            "--bind-address",
+            "scripts/stegdeploy_native_gateway.py",
+            "start",
+            "--host",
             str(tls_request["bind_address"]),
             "--port",
             str(port),
@@ -285,7 +303,12 @@ def validate_readiness(payload: dict[str, Any], decision: dict[str, Any]) -> Non
         raise GatewayActivationError("READINESS_BOUNDARY_INVALID:" + ",".join(sorted(failed)))
 
 
-def _clean_env(decision: dict[str, Any]) -> dict[str, str]:
+def _clean_env(
+    decision: dict[str, Any],
+    *,
+    tls_request: dict[str, Any] | None = None,
+    evaluator: dict[str, Any] | None = None,
+) -> dict[str, str]:
     present = [name for name in FORBIDDEN_ENV if os.getenv(name)]
     if present:
         raise GatewayActivationError("FORBIDDEN_CREDENTIAL_ENV:" + ",".join(sorted(present)))
@@ -298,9 +321,18 @@ def _clean_env(decision: dict[str, Any]) -> dict[str, str]:
         "STEGVERSE_PROVIDER_ENABLED": "false",
         "STEGVERSE_EXTERNAL_MUTATION_ENABLED": "false",
     }
-    for name in ("XDG_STATE_HOME", "XDG_CONFIG_HOME"):
+    for name in ("XDG_STATE_HOME", "XDG_CONFIG_HOME", "STEGVERSE_SERVICE_GATEWAY_NATIVE_STATE_ROOT"):
         if os.getenv(name):
             env[name] = os.environ[name]
+    if tls_request is not None:
+        env["STEGDEPLOY_NATIVE_TLS_CERT_FILE"] = str(tls_request["cert_file"])
+        env["STEGDEPLOY_NATIVE_TLS_KEY_FILE"] = str(tls_request["key_file"])
+    if evaluator and evaluator.get("enabled") is True:
+        env[EVALUATOR_ENABLED_ENV] = "true"
+        env[EVALUATOR_UPSTREAM_ENV] = str(evaluator["upstream"])
+    else:
+        env[EVALUATOR_ENABLED_ENV] = "false"
+        env[EVALUATOR_UPSTREAM_ENV] = ""
     return env
 
 
@@ -315,19 +347,17 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
 
     tls_request = resolve_tls_request()
     required = [
-        llm_root / "scripts/stegdeploy_bootstrap.py",
-        llm_root / "compose.stegdeploy.yaml",
+        llm_root / "scripts/stegdeploy_native_gateway.py",
         llm_root / "llm_adapter/deployed_gateway.py",
         llm_root / "llm_adapter/service_gateway_composed.py",
     ]
-    if tls_request is not None:
-        required.append(llm_root / "compose.stegdeploy.tls.yaml")
     missing = [str(path.relative_to(llm_root)) for path in required if not path.is_file()]
     if missing:
         raise GatewayActivationError("LLM_ADAPTER_STEGDEPLOY_SOURCE_INCOMPLETE:" + ",".join(missing))
 
     decision_path, decision = locate_decision(tvc_root)
-    env = _clean_env(decision)
+    evaluator = evaluator_runtime_config()
+    env = _clean_env(decision, tls_request=tls_request, evaluator=evaluator)
 
     head = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=llm_root, env={"PATH": env["PATH"]},
@@ -356,6 +386,8 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
             "provider_operation_started": False,
             "production_public_route_observed": False,
             "tls_enabled": tls_enabled,
+            "runtime_topology": "HOST_NATIVE_PYTHON_UVICORN",
+            "evaluator_intr_enabled": evaluator["enabled"],
             "authority_effect": "NONE",
         }
 
@@ -383,6 +415,10 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
         "github_token_required": False,
         "render_required": False,
         "tls_enabled": tls_enabled,
+        "runtime_topology": "HOST_NATIVE_PYTHON_UVICORN",
+        "docker_required": False,
+        "evaluator_intr_enabled": evaluator["enabled"],
+        "evaluator_intr_upstream": evaluator["upstream"] if evaluator["enabled"] else None,
         "tls_locator_source": str(tls_request.get("locator_source")) if tls_enabled and tls_request else "NONE",
         "tls_adoption_receipt_sha256": tls_request.get("adoption_receipt_sha256") if tls_enabled and tls_request else None,
         "tls_private_key_material_recorded": False,

--- a/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
+++ b/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
@@ -294,3 +294,41 @@ local native-TLS Gateway execution: NOT OBSERVED
 public HTTPS route: NOT OBSERVED
 G18 resident request consumption: NOT OBSERVED
 ```
+
+
+## Host-native shared Gateway activation topology — 2026-08-29
+
+Downstream of `StegVerse-org/LLM-adapter#224/#225`, the fixed Healer Service Gateway target now requires the host-native launcher:
+
+```text
+scripts/stegdeploy_native_gateway.py
+```
+
+The prior Docker bootstrap remains a repository compatibility surface but is no longer used by this machine-owned sovereign activation target.
+
+Reason:
+
+```text
+Docker container 127.0.0.1 != sovereign host 127.0.0.1
+```
+
+The evaluator READ_REVIEW runtime is intentionally same-host loopback. The activation target therefore uses:
+
+```text
+host-native deployed_gateway
+-> optional explicitly materialized evaluator enablement
+-> http://127.0.0.1:8765/intr/evaluator
+```
+
+Evaluator configuration remains fail-closed:
+
+- default `STEGVERSE_EVALUATOR_INTR_ENABLED=false`;
+- when enabled, upstream must equal the exact canonical loopback URI;
+- no remote evaluator proxy target is accepted;
+- configuration is non-secret and does not grant authority.
+
+TLS paths remain confined to TV/TVC and are delivered to the native launcher through the child environment rather than embedded in the launcher command. Receipt/result state does not serialize the private-key path or bytes.
+
+The Healer result now records `runtime_topology=HOST_NATIVE_PYTHON_UVICORN` and `docker_required=false`. It still records public reachability and hostname verification as false until independently observed.
+
+This source change does not establish a live native Gateway, TLS adoption, public route, or evaluator resident execution.

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -246,7 +246,7 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
                 os.environ.clear()
                 os.environ.update(old)
 
-    def test_tls_deploy_command_uses_existing_bootstrap_without_secret_values(self) -> None:
+    def test_tls_deploy_command_uses_native_gateway_without_secret_values(self) -> None:
         request = {
             "cert_file": Path("/runtime/tvc/gateway-cert.pem"),
             "key_file": Path("/runtime/tvc/gateway-key.pem"),
@@ -255,9 +255,10 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
         }
         command, readiness_url, tls_enabled = mod.build_deploy_command(request)
         self.assertTrue(tls_enabled)
-        self.assertIn("deploy-tls", command)
-        self.assertIn("/runtime/tvc/gateway-cert.pem", command)
-        self.assertIn("/runtime/tvc/gateway-key.pem", command)
+        self.assertIn("scripts/stegdeploy_native_gateway.py", command)
+        self.assertIn("start", command)
+        self.assertNotIn("/runtime/tvc/gateway-cert.pem", command)
+        self.assertNotIn("/runtime/tvc/gateway-key.pem", command)
         self.assertIn("0.0.0.0", command)
         self.assertIn("443", command)
         self.assertEqual(readiness_url, "https://127.0.0.1:443/api/coinbase/skap/readiness")
@@ -267,9 +268,49 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
     def test_http_mode_remains_local_and_non_public(self) -> None:
         command, readiness_url, tls_enabled = mod.build_deploy_command(None)
         self.assertFalse(tls_enabled)
-        self.assertIn("deploy", command)
+        self.assertIn("scripts/stegdeploy_native_gateway.py", command)
+        self.assertIn("start", command)
         self.assertEqual(readiness_url, mod.READINESS_URL)
         self.assertTrue(readiness_url.startswith("http://127.0.0.1:"))
+
+
+    def test_evaluator_runtime_config_is_fail_closed_and_loopback_only(self) -> None:
+        import os
+        old = dict(os.environ)
+        try:
+            os.environ.pop(mod.EVALUATOR_ENABLED_ENV, None)
+            os.environ.pop(mod.EVALUATOR_UPSTREAM_ENV, None)
+            disabled = mod.evaluator_runtime_config()
+            self.assertFalse(disabled["enabled"])
+
+            os.environ[mod.EVALUATOR_ENABLED_ENV] = "true"
+            os.environ[mod.EVALUATOR_UPSTREAM_ENV] = mod.EVALUATOR_LOOPBACK_UPSTREAM
+            enabled = mod.evaluator_runtime_config()
+            self.assertTrue(enabled["enabled"])
+            self.assertEqual(enabled["upstream"], mod.EVALUATOR_LOOPBACK_UPSTREAM)
+
+            os.environ[mod.EVALUATOR_UPSTREAM_ENV] = "http://192.0.2.9:8765/intr/evaluator"
+            with self.assertRaisesRegex(mod.GatewayActivationError, "NOT_CANONICAL_LOOPBACK"):
+                mod.evaluator_runtime_config()
+        finally:
+            os.environ.clear()
+            os.environ.update(old)
+
+    def test_clean_env_carries_tls_paths_and_evaluator_only_as_runtime_config(self) -> None:
+        request = {
+            "cert_file": Path("/run/stegverse/tv-tvc-credentials/cert.pem"),
+            "key_file": Path("/run/stegverse/tv-tvc-credentials/key.pem"),
+        }
+        env = mod._clean_env(
+            self.decision(),
+            tls_request=request,
+            evaluator={"enabled": True, "upstream": mod.EVALUATOR_LOOPBACK_UPSTREAM},
+        )
+        self.assertEqual(env["STEGDEPLOY_NATIVE_TLS_CERT_FILE"], str(request["cert_file"]))
+        self.assertEqual(env["STEGDEPLOY_NATIVE_TLS_KEY_FILE"], str(request["key_file"]))
+        self.assertEqual(env[mod.EVALUATOR_ENABLED_ENV], "true")
+        self.assertEqual(env[mod.EVALUATOR_UPSTREAM_ENV], mod.EVALUATOR_LOOPBACK_UPSTREAM)
+        self.assertNotIn("GITHUB_TOKEN", env)
 
     def test_scheduler_target_is_registered_and_bounded(self) -> None:
         root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
Closes #45. Updates the fixed Healer shared-Gateway target to require the host-native LLM-adapter launcher, eliminating the Docker namespace mismatch for same-host evaluator InTr. TV/TVC TLS locators are passed through the runtime environment, evaluator enablement remains explicit and exact-loopback-only, and all public-route/activation distinctions remain fail-closed. Depends on LLM-adapter #225.