### PR TITLE
Require SV002 route readiness in sovereign Gateway activation

### DIFF
--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -31,6 +31,7 @@ EVALUATOR_LOOPBACK_UPSTREAM = "http://127.0.0.1:8765/intr/evaluator"
 SV002_OBSERVE_ENABLED_ENV = "STEGVERSE_SV002_OBSERVE_ENABLED"
 SV002_OBSERVE_UPSTREAM_ENV = "STEGVERSE_SV002_OBSERVE_UPSTREAM"
 SV002_OBSERVE_LOOPBACK_UPSTREAM = "http://127.0.0.1:8766/intr/sv002-observe"
+SV002_GATEWAY_READINESS_PATH = "/intr/sv002-observe/readiness"
 FORBIDDEN_ENV = (
     "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
     "GH_STEGVERSE_AI_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
@@ -317,6 +318,33 @@ def validate_readiness(payload: dict[str, Any], decision: dict[str, Any]) -> Non
         raise GatewayActivationError("READINESS_BOUNDARY_INVALID:" + ",".join(sorted(failed)))
 
 
+def validate_sv002_gateway_readiness(payload: dict[str, Any]) -> None:
+    expected = {
+        "schema": "stegverse.service-gateway.sv002-observation-readiness/v1",
+        "enabled": True,
+        "loopback_upstream_configured": True,
+        "state": "READY",
+        "transport": "InTr",
+        "credential_authority": "TV/TVC",
+        "gateway_receipt_authority": False,
+        "gateway_experiment_authority": False,
+        "authority_effect": "NONE",
+    }
+    failed = [key for key, value in expected.items() if payload.get(key) != value]
+    if failed:
+        raise GatewayActivationError(
+            "SV002_OBSERVATION_GATEWAY_READINESS_INVALID:" + ",".join(sorted(failed))
+        )
+
+
+def _sv002_gateway_readiness_url(*, tls_enabled: bool, tls_request: dict[str, Any] | None) -> str:
+    if tls_enabled:
+        if tls_request is None:
+            raise GatewayActivationError("SV002_OBSERVATION_TLS_REQUEST_MISSING")
+        return f"https://127.0.0.1:{int(tls_request['port'])}{SV002_GATEWAY_READINESS_PATH}"
+    return "http://127.0.0.1:8000" + SV002_GATEWAY_READINESS_PATH
+
+
 def _clean_env(
     decision: dict[str, Any],
     *,
@@ -424,6 +452,28 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
         raise GatewayActivationError("LOCAL_COINBASE_READINESS_OBJECT_REQUIRED")
     validate_readiness(payload, decision)
 
+    sv002_readiness = None
+    sv002_readiness_url = None
+    if sv002_observe["enabled"]:
+        sv002_readiness_url = _sv002_gateway_readiness_url(
+            tls_enabled=tls_enabled,
+            tls_request=tls_request,
+        )
+        try:
+            with urllib.request.urlopen(
+                sv002_readiness_url,
+                timeout=5,
+                context=context,
+            ) as response:
+                sv002_readiness = json.loads(response.read().decode("utf-8"))
+        except Exception as exc:
+            raise GatewayActivationError(
+                "LOCAL_SV002_OBSERVATION_GATEWAY_READINESS_UNAVAILABLE:" + type(exc).__name__
+            ) from exc
+        if not isinstance(sv002_readiness, dict):
+            raise GatewayActivationError("LOCAL_SV002_OBSERVATION_GATEWAY_READINESS_OBJECT_REQUIRED")
+        validate_sv002_gateway_readiness(sv002_readiness)
+
     return {
         "schema": "stegverse.healer.coinbase_stegdeploy_gateway_activation/v1",
         "state": "COMPLETE",
@@ -433,6 +483,8 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
         "decision_id": decision["decision_id"],
         "readiness_url": readiness_url,
         "readiness": payload,
+        "sv002_observation_readiness_url": sv002_readiness_url,
+        "sv002_observation_readiness": sv002_readiness,
         "credential_authority": "TV/TVC",
         "credential_material_present": False,
         "github_token_required": False,

--- a/docs/SV002_SERVICE_GATEWAY_READINESS_MIRROR_HANDOFF.md
+++ b/docs/SV002_SERVICE_GATEWAY_READINESS_MIRROR_HANDOFF.md
@@ -1,0 +1,63 @@
+# SV002 Service Gateway Readiness Mirror Handoff
+
+Updated: 2026-08-29
+Repository: StegVerse-Labs/StegVerse-Healer
+Issue: #49
+Branch: fix/sv002-gateway-readiness-49
+
+## Source of truth
+
+This file is the current handoff and task source of truth for the bounded StegVerse-002 observation readiness verification inside the existing sovereign Service Gateway activation target.
+
+## Scope
+
+When `STEGVERSE_SV002_OBSERVE_ENABLED=true`, Healer must not report the shared Gateway target COMPLETE merely because the Coinbase readiness surface is healthy. It must additionally observe the deployed Gateway's own:
+
+```text
+GET /intr/sv002-observe/readiness
+```
+
+and require the exact authority-neutral projection:
+
+```text
+schema: stegverse.service-gateway.sv002-observation-readiness/v1
+enabled: true
+loopback_upstream_configured: true
+state: READY
+transport: InTr
+credential_authority: TV/TVC
+gateway_receipt_authority: false
+gateway_experiment_authority: false
+authority_effect: NONE
+```
+
+This verifies Gateway configuration/readiness only. It does not establish the resident SV002 receiver process, public Internet route, valid external observer round trip, principal experiment execution, or Master Records custody.
+
+## Existing owners retained
+
+- shared Service Gateway implementation: StegVerse-org/LLM-adapter
+- SV002 receiver/runtime task: StegVerse-Labs/.github#462 / SHWP-SV002-PUBLIC-OBSERVATION-RUNTIME-001
+- credential/TLS authority: TV/TVC
+- resident scheduler: SHWP-HEALER-SOVEREIGN-SCHEDULER-001
+- custody/reconstruction: master-records/orchestration
+
+No second Gateway, scheduler, heartbeat, TLS authority, or credential surface may be created.
+
+## Files
+
+- `app/coinbase_stegdeploy_gateway.py`
+- `tests/test_coinbase_stegdeploy_gateway.py`
+- `docs/SV002_SERVICE_GATEWAY_READINESS_MIRROR_HANDOFF.md`
+
+## Remaining installation / integration destinations
+
+- resident Healer scheduler execution -> StegVerse-Labs/.github sovereign runtime
+- persistent SV002 receiver -> StegVerse-Labs/.github
+- public Gateway route/TLS -> StegVerse-org/LLM-adapter + StegVerse-Labs/TVC
+- Site browser observation -> StegVerse-Labs/Site
+- experiment artifacts -> StegVerse-002/micro-node-runtime
+- custody/reconstruction -> master-records/orchestration
+
+## Completion
+
+Source completion requires deterministic tests, repository validation, merge to main, and issue reconciliation. Runtime activation remains separately evidence-gated.

--- a/tests/test_coinbase_stegdeploy_gateway.py
+++ b/tests/test_coinbase_stegdeploy_gateway.py
@@ -344,6 +344,48 @@ class CoinbaseStegDeployGatewayTests(unittest.TestCase):
         self.assertEqual(env[mod.SV002_OBSERVE_UPSTREAM_ENV], mod.SV002_OBSERVE_LOOPBACK_UPSTREAM)
         self.assertNotIn("GITHUB_TOKEN", env)
 
+
+    def test_sv002_gateway_readiness_requires_exact_authority_neutral_projection(self) -> None:
+        payload = {
+            "schema": "stegverse.service-gateway.sv002-observation-readiness/v1",
+            "enabled": True,
+            "loopback_upstream_configured": True,
+            "state": "READY",
+            "transport": "InTr",
+            "credential_authority": "TV/TVC",
+            "gateway_receipt_authority": False,
+            "gateway_experiment_authority": False,
+            "authority_effect": "NONE",
+        }
+        mod.validate_sv002_gateway_readiness(payload)
+        bad = dict(payload)
+        bad["gateway_experiment_authority"] = True
+        with self.assertRaisesRegex(
+            mod.GatewayActivationError,
+            "SV002_OBSERVATION_GATEWAY_READINESS_INVALID",
+        ):
+            mod.validate_sv002_gateway_readiness(bad)
+
+    def test_sv002_gateway_readiness_url_tracks_existing_native_gateway_mode(self) -> None:
+        self.assertEqual(
+            mod._sv002_gateway_readiness_url(tls_enabled=False, tls_request=None),
+            "http://127.0.0.1:8000/intr/sv002-observe/readiness",
+        )
+        self.assertEqual(
+            mod._sv002_gateway_readiness_url(
+                tls_enabled=True,
+                tls_request={"port": 443},
+            ),
+            "https://127.0.0.1:443/intr/sv002-observe/readiness",
+        )
+
+    def test_sv002_readiness_is_required_only_when_observation_route_enabled(self) -> None:
+        source = Path(mod.__file__).read_text(encoding="utf-8")
+        self.assertIn('if sv002_observe["enabled"]:', source)
+        self.assertIn("validate_sv002_gateway_readiness(sv002_readiness)", source)
+        self.assertIn("LOCAL_SV002_OBSERVATION_GATEWAY_READINESS_UNAVAILABLE", source)
+
+
     def test_scheduler_target_is_registered_and_bounded(self) -> None:
         root = Path(__file__).resolve().parents[1]
         config = json.loads((root / "data/orchestrator_targets.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
Closes the bounded source gap in #49. When the existing shared sovereign Gateway is configured with `STEGVERSE_SV002_OBSERVE_ENABLED=true`, the Healer activation target now also reads `/intr/sv002-observe/readiness` from the already-started local/native Gateway and requires the exact TV/TVC, InTr, authority-neutral READY projection before reporting COMPLETE. HTTP and native-TLS modes reuse the same Gateway. No second Gateway/scheduler/TLS authority is created, and no resident receiver, public Internet route, experiment execution, or custody is inferred from this source validation.