### PR TITLE
Bind Universal InTr to sovereign Gateway

### DIFF
--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -32,6 +32,10 @@ SV002_OBSERVE_ENABLED_ENV = "STEGVERSE_SV002_OBSERVE_ENABLED"
 SV002_OBSERVE_UPSTREAM_ENV = "STEGVERSE_SV002_OBSERVE_UPSTREAM"
 SV002_OBSERVE_LOOPBACK_UPSTREAM = "http://127.0.0.1:8766/intr/sv002-observe"
 SV002_GATEWAY_READINESS_PATH = "/intr/sv002-observe/readiness"
+HIL_INTR_ENABLED_ENV = "STEGVERSE_HIL_INTR_ENABLED"
+HIL_INTR_UPSTREAM_ENV = "STEGVERSE_HIL_INTR_UPSTREAM"
+HIL_INTR_LOOPBACK_UPSTREAM = "http://127.0.0.1:8765/intr/materialization"
+HIL_INTR_GATEWAY_READINESS_PATH = "/intr/materialization/readiness"
 FORBIDDEN_ENV = (
     "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
     "GH_STEGVERSE_AI_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
@@ -213,6 +217,50 @@ def sv002_observation_runtime_config() -> dict[str, Any]:
     return {"enabled": enabled, "upstream": upstream if enabled else ""}
 
 
+
+def hil_intr_runtime_config() -> dict[str, Any]:
+    raw = os.getenv(HIL_INTR_ENABLED_ENV, "false").strip().lower()
+    if raw not in {"true", "false", "1", "0", "yes", "no"}:
+        raise GatewayActivationError("HIL_INTR_ENABLED_INVALID")
+    enabled = raw in {"true", "1", "yes"}
+    upstream = os.getenv(HIL_INTR_UPSTREAM_ENV, HIL_INTR_LOOPBACK_UPSTREAM).strip()
+    if enabled and upstream != HIL_INTR_LOOPBACK_UPSTREAM:
+        raise GatewayActivationError("HIL_INTR_UPSTREAM_NOT_CANONICAL_LOOPBACK")
+    return {"enabled": enabled, "upstream": upstream if enabled else ""}
+
+
+def validate_hil_intr_gateway_readiness(payload: dict[str, Any]) -> None:
+    expected = {
+        "schema": "stegverse.service-gateway.hil-intr-readiness/v1",
+        "enabled": True,
+        "loopback_upstream_configured": True,
+        "state": "READY",
+        "transport": "InTr",
+        "event_triggered": True,
+        "always_on_receiver_required": False,
+        "second_user_device_required": False,
+        "g18_completion_required": False,
+        "credential_authority": "TV/TVC",
+        "github_token_runtime_authority": "NONE",
+        "gateway_receipt_authority": False,
+        "gateway_execution_authority": False,
+        "gateway_custody_authority": False,
+        "authority_effect": "NONE",
+    }
+    failed = [key for key, value in expected.items() if payload.get(key) != value]
+    if failed:
+        raise GatewayActivationError(
+            "HIL_INTR_GATEWAY_READINESS_INVALID:" + ",".join(sorted(failed))
+        )
+
+
+def _hil_intr_gateway_readiness_url(*, tls_enabled: bool, tls_request: dict[str, Any] | None) -> str:
+    if tls_enabled:
+        if tls_request is None:
+            raise GatewayActivationError("HIL_INTR_TLS_REQUEST_MISSING")
+        return f"https://127.0.0.1:{int(tls_request['port'])}{HIL_INTR_GATEWAY_READINESS_PATH}"
+    return "http://127.0.0.1:8000" + HIL_INTR_GATEWAY_READINESS_PATH
+
 def build_deploy_command(tls_request: dict[str, Any] | None) -> tuple[list[str], str, bool]:
     if tls_request is None:
         return (
@@ -351,6 +399,7 @@ def _clean_env(
     tls_request: dict[str, Any] | None = None,
     evaluator: dict[str, Any] | None = None,
     sv002_observe: dict[str, Any] | None = None,
+    hil_intr: dict[str, Any] | None = None,
 ) -> dict[str, str]:
     present = [name for name in FORBIDDEN_ENV if os.getenv(name)]
     if present:
@@ -382,6 +431,12 @@ def _clean_env(
     else:
         env[SV002_OBSERVE_ENABLED_ENV] = "false"
         env[SV002_OBSERVE_UPSTREAM_ENV] = ""
+    if hil_intr and hil_intr.get("enabled") is True:
+        env[HIL_INTR_ENABLED_ENV] = "true"
+        env[HIL_INTR_UPSTREAM_ENV] = str(hil_intr["upstream"])
+    else:
+        env[HIL_INTR_ENABLED_ENV] = "false"
+        env[HIL_INTR_UPSTREAM_ENV] = ""
     return env
 
 
@@ -399,6 +454,7 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
         llm_root / "scripts/stegdeploy_native_gateway.py",
         llm_root / "llm_adapter/deployed_gateway.py",
         llm_root / "llm_adapter/service_gateway_composed.py",
+        llm_root / "llm_adapter/service_gateway_hil_intr.py",
     ]
     missing = [str(path.relative_to(llm_root)) for path in required if not path.is_file()]
     if missing:
@@ -407,7 +463,8 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
     decision_path, decision = locate_decision(tvc_root)
     evaluator = evaluator_runtime_config()
     sv002_observe = sv002_observation_runtime_config()
-    env = _clean_env(decision, tls_request=tls_request, evaluator=evaluator, sv002_observe=sv002_observe)
+    hil_intr = hil_intr_runtime_config()
+    env = _clean_env(decision, tls_request=tls_request, evaluator=evaluator, sv002_observe=sv002_observe, hil_intr=hil_intr)
 
     head = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=llm_root, env={"PATH": env["PATH"]},

--- a/app/coinbase_stegdeploy_gateway.py
+++ b/app/coinbase_stegdeploy_gateway.py
@@ -36,6 +36,7 @@ HIL_INTR_ENABLED_ENV = "STEGVERSE_HIL_INTR_ENABLED"
 HIL_INTR_UPSTREAM_ENV = "STEGVERSE_HIL_INTR_UPSTREAM"
 HIL_INTR_LOOPBACK_UPSTREAM = "http://127.0.0.1:8765/intr/materialization"
 HIL_INTR_GATEWAY_READINESS_PATH = "/intr/materialization/readiness"
+MINIMUM_UNIVERSAL_INTR_GATEWAY_COMMIT = "49676d20cff32ee346f22cfd79726b0127d80b33"
 FORBIDDEN_ENV = (
     "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "HEALER_GH_TOKEN", "HEALER_PAT",
     "GH_STEGVERSE_AI_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
@@ -473,6 +474,12 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
     source_head = head.stdout.strip().lower()
     if head.returncode != 0 or len(source_head) != 40:
         raise GatewayActivationError("LLM_ADAPTER_SOURCE_HEAD_UNPROVEN")
+    ancestry = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", MINIMUM_UNIVERSAL_INTR_GATEWAY_COMMIT, "HEAD"],
+        cwd=llm_root, env={"PATH": env["PATH"]}, text=True, capture_output=True, check=False, timeout=30,
+    )
+    if ancestry.returncode != 0:
+        raise GatewayActivationError("LLM_ADAPTER_UNIVERSAL_INTR_GATEWAY_SOURCE_STALE")
 
     deploy_command, readiness_url, tls_enabled = build_deploy_command(tls_request)
     deploy = subprocess.run(
@@ -496,6 +503,8 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
             "runtime_topology": "HOST_NATIVE_PYTHON_UVICORN",
             "evaluator_intr_enabled": evaluator["enabled"],
             "sv002_observation_enabled": sv002_observe["enabled"],
+            "hil_intr_enabled": hil_intr["enabled"],
+            "minimum_universal_intr_gateway_commit": MINIMUM_UNIVERSAL_INTR_GATEWAY_COMMIT,
             "authority_effect": "NONE",
         }
 
@@ -531,6 +540,28 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
             raise GatewayActivationError("LOCAL_SV002_OBSERVATION_GATEWAY_READINESS_OBJECT_REQUIRED")
         validate_sv002_gateway_readiness(sv002_readiness)
 
+    hil_intr_readiness = None
+    hil_intr_readiness_url = None
+    if hil_intr["enabled"]:
+        hil_intr_readiness_url = _hil_intr_gateway_readiness_url(
+            tls_enabled=tls_enabled,
+            tls_request=tls_request,
+        )
+        try:
+            with urllib.request.urlopen(
+                hil_intr_readiness_url,
+                timeout=5,
+                context=context,
+            ) as response:
+                hil_intr_readiness = json.loads(response.read().decode("utf-8"))
+        except Exception as exc:
+            raise GatewayActivationError(
+                "LOCAL_HIL_INTR_GATEWAY_READINESS_UNAVAILABLE:" + type(exc).__name__
+            ) from exc
+        if not isinstance(hil_intr_readiness, dict):
+            raise GatewayActivationError("LOCAL_HIL_INTR_GATEWAY_READINESS_OBJECT_REQUIRED")
+        validate_hil_intr_gateway_readiness(hil_intr_readiness)
+
     return {
         "schema": "stegverse.healer.coinbase_stegdeploy_gateway_activation/v1",
         "state": "COMPLETE",
@@ -542,6 +573,8 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
         "readiness": payload,
         "sv002_observation_readiness_url": sv002_readiness_url,
         "sv002_observation_readiness": sv002_readiness,
+        "hil_intr_readiness_url": hil_intr_readiness_url,
+        "hil_intr_readiness": hil_intr_readiness,
         "credential_authority": "TV/TVC",
         "credential_material_present": False,
         "github_token_required": False,
@@ -553,6 +586,10 @@ def execute(roots_json: str | None = None) -> dict[str, Any]:
         "evaluator_intr_upstream": evaluator["upstream"] if evaluator["enabled"] else None,
         "sv002_observation_enabled": sv002_observe["enabled"],
         "sv002_observation_upstream": sv002_observe["upstream"] if sv002_observe["enabled"] else None,
+        "hil_intr_enabled": hil_intr["enabled"],
+        "hil_intr_upstream": hil_intr["upstream"] if hil_intr["enabled"] else None,
+        "minimum_universal_intr_gateway_commit": MINIMUM_UNIVERSAL_INTR_GATEWAY_COMMIT,
+        "minimum_universal_intr_gateway_commit_ancestor": True,
         "tls_locator_source": str(tls_request.get("locator_source")) if tls_enabled and tls_request else "NONE",
         "tls_adoption_receipt_sha256": tls_request.get("adoption_receipt_sha256") if tls_enabled and tls_request else None,
         "tls_private_key_material_recorded": False,

--- a/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
+++ b/docs/COINBASE_STEGDEPLOY_GATEWAY_ACTIVATION_MIRROR_HANDOFF.md
@@ -332,3 +332,22 @@ TLS paths remain confined to TV/TVC and are delivered to the native launcher thr
 The Healer result now records `runtime_topology=HOST_NATIVE_PYTHON_UVICORN` and `docker_required=false`. It still records public reachability and hostname verification as false until independently observed.
 
 This source change does not establish a live native Gateway, TLS adoption, public route, or evaluator resident execution.
+
+
+## Universal InTr public-profile runtime binding — 2026-08-31
+
+Public observation from `StegVerse-Labs/Site#860` established that `https://stegverse.org/intr/profile` returned HTTP 404 on eight independent attempts. LLM-adapter source already contains the route through PR #244 / merge `49676d20cff32ee346f22cfd79726b0127d80b33`, so the observed failure is runtime publication/binding drift rather than missing Gateway router source.
+
+The fixed sovereign Gateway handler now consumes the existing resident Universal InTr route projection:
+
+```text
+STEGVERSE_HIL_INTR_ENABLED=true
+STEGVERSE_HIL_INTR_UPSTREAM=http://127.0.0.1:8765/intr/materialization
+```
+
+When enabled it requires:
+- the exact canonical same-host upstream;
+- local LLM-adapter HEAD to contain merge `49676d20cff32ee346f22cfd79726b0127d80b33` as an ancestor;
+- `/intr/materialization/readiness` to report READY, event-triggered, G18-independent, TV/TVC-bound, no GitHub authority, and no receipt/execution/custody authority.
+
+The binding is configuration/transport only. Local readiness remains distinct from public HTTPS observation. A source merge or local READY result does not establish `https://stegverse.org/intr/profile`; that route must be re-observed independently after authentic resident publication.

--- a/docs/SV002_SERVICE_GATEWAY_READINESS_MIRROR_HANDOFF.md
+++ b/docs/SV002_SERVICE_GATEWAY_READINESS_MIRROR_HANDOFF.md
@@ -61,3 +61,22 @@ No second Gateway, scheduler, heartbeat, TLS authority, or credential surface ma
 ## Completion
 
 Source completion requires deterministic tests, repository validation, merge to main, and issue reconciliation. Runtime activation remains separately evidence-gated.
+
+
+## Universal InTr public-profile runtime binding — 2026-08-31
+
+Public observation from `StegVerse-Labs/Site#860` established that `https://stegverse.org/intr/profile` returned HTTP 404 on eight independent attempts. LLM-adapter source already contains the route through PR #244 / merge `49676d20cff32ee346f22cfd79726b0127d80b33`, so the observed failure is runtime publication/binding drift rather than missing Gateway router source.
+
+The fixed sovereign Gateway handler now consumes the existing resident Universal InTr route projection:
+
+```text
+STEGVERSE_HIL_INTR_ENABLED=true
+STEGVERSE_HIL_INTR_UPSTREAM=http://127.0.0.1:8765/intr/materialization
+```
+
+When enabled it requires:
+- the exact canonical same-host upstream;
+- local LLM-adapter HEAD to contain merge `49676d20cff32ee346f22cfd79726b0127d80b33` as an ancestor;
+- `/intr/materialization/readiness` to report READY, event-triggered, G18-independent, TV/TVC-bound, no GitHub authority, and no receipt/execution/custody authority.
+
+The binding is configuration/transport only. Local readiness remains distinct from public HTTPS observation. A source merge or local READY result does not establish `https://stegverse.org/intr/profile`; that route must be re-observed independently after authentic resident publication.

--- a/tests/test_universal_intr_gateway_binding.py
+++ b/tests/test_universal_intr_gateway_binding.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from app import coinbase_stegdeploy_gateway as mod
+
+
+class UniversalInTrGatewayBindingTests(unittest.TestCase):
+    def test_exact_canonical_upstream_enabled(self):
+        with patch.dict(os.environ, {
+            mod.HIL_INTR_ENABLED_ENV: "true",
+            mod.HIL_INTR_UPSTREAM_ENV: mod.HIL_INTR_LOOPBACK_UPSTREAM,
+        }, clear=False):
+            self.assertEqual(mod.hil_intr_runtime_config(), {
+                "enabled": True,
+                "upstream": "http://127.0.0.1:8765/intr/materialization",
+            })
+
+    def test_remote_or_wrong_loopback_upstream_rejected(self):
+        for upstream in (
+            "https://remote.example/intr/materialization",
+            "http://127.0.0.1:9999/intr/materialization",
+            "http://127.0.0.1:8765/other",
+        ):
+            with patch.dict(os.environ, {
+                mod.HIL_INTR_ENABLED_ENV: "true",
+                mod.HIL_INTR_UPSTREAM_ENV: upstream,
+            }, clear=False):
+                with self.assertRaisesRegex(mod.GatewayActivationError, "HIL_INTR_UPSTREAM_NOT_CANONICAL_LOOPBACK"):
+                    mod.hil_intr_runtime_config()
+
+    def test_disabled_route_does_not_expose_upstream(self):
+        with patch.dict(os.environ, {
+            mod.HIL_INTR_ENABLED_ENV: "false",
+            mod.HIL_INTR_UPSTREAM_ENV: "",
+        }, clear=False):
+            self.assertEqual(mod.hil_intr_runtime_config(), {"enabled": False, "upstream": ""})
+
+    def test_readiness_contract_accepts_exact_non_authorizing_profile(self):
+        mod.validate_hil_intr_gateway_readiness({
+            "schema": "stegverse.service-gateway.hil-intr-readiness/v1",
+            "enabled": True,
+            "loopback_upstream_configured": True,
+            "state": "READY",
+            "transport": "InTr",
+            "supported_origins": ["STEGOS_NODE_OUTBOX", "TVC_RELAY_EGRESS"],
+            "event_triggered": True,
+            "always_on_receiver_required": False,
+            "second_user_device_required": False,
+            "g18_completion_required": False,
+            "credential_authority": "TV/TVC",
+            "github_token_runtime_authority": "NONE",
+            "gateway_receipt_authority": False,
+            "gateway_execution_authority": False,
+            "gateway_custody_authority": False,
+            "authority_effect": "NONE",
+            "reason": None,
+        })
+
+    def test_readiness_contract_rejects_execution_authority(self):
+        payload = {
+            "schema": "stegverse.service-gateway.hil-intr-readiness/v1",
+            "enabled": True,
+            "loopback_upstream_configured": True,
+            "state": "READY",
+            "transport": "InTr",
+            "event_triggered": True,
+            "always_on_receiver_required": False,
+            "second_user_device_required": False,
+            "g18_completion_required": False,
+            "credential_authority": "TV/TVC",
+            "github_token_runtime_authority": "NONE",
+            "gateway_receipt_authority": False,
+            "gateway_execution_authority": True,
+            "gateway_custody_authority": False,
+            "authority_effect": "NONE",
+        }
+        with self.assertRaisesRegex(mod.GatewayActivationError, "gateway_execution_authority"):
+            mod.validate_hil_intr_gateway_readiness(payload)
+
+    def test_clean_env_propagates_only_nonsecret_hil_intr_binding(self):
+        env = mod._clean_env(
+            {"decision_id": "sha256:" + "a" * 64},
+            hil_intr={"enabled": True, "upstream": mod.HIL_INTR_LOOPBACK_UPSTREAM},
+        )
+        self.assertEqual(env[mod.HIL_INTR_ENABLED_ENV], "true")
+        self.assertEqual(env[mod.HIL_INTR_UPSTREAM_ENV], mod.HIL_INTR_LOOPBACK_UPSTREAM)
+        self.assertNotIn("GITHUB_TOKEN", env)
+
+    def test_minimum_gateway_commit_is_profile_projection_merge(self):
+        self.assertEqual(
+            mod.MINIMUM_UNIVERSAL_INTR_GATEWAY_COMMIT,
+            "49676d20cff32ee346f22cfd79726b0127d80b33",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #52.

Consumes the existing Universal InTr route projection in the canonical fixed StegDeploy handler. When enabled, it accepts only `http://127.0.0.1:8765/intr/materialization`, requires local LLM-adapter source to contain the merged public-profile implementation `49676d20cff32ee346f22cfd79726b0127d80b33`, propagates the non-secret binding to `llm_adapter.deployed_gateway:app`, and requires exact `/intr/materialization/readiness` before local target completion. It creates no new gateway/scheduler/authority and makes no public-route claim from local readiness.