### PR TITLE
Reconcile Healer scheduler with G18 gate retirement

### DIFF
--- a/data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json
+++ b/data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json
@@ -96,10 +96,11 @@
     "organization_handoff": "StegVerse-Labs/.github/docs/ORG_MIRROR_HANDOFF.md",
     "worker_handoff": "StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json",
     "worker_registry_fragment": "StegVerse-Labs/.github/control/worker-registry.d/healer-sovereign-scheduler-001.json",
-    "runtime_activation_handoff": "StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json",
-    "execution_owner": "resident sovereign heartbeat",
-    "next_executable_action": "Resident carrier admits and executes the Healer sovereign scheduler under the current heartbeat claim/fence; persist its no-token receipt and continue fail-closed target reconciliation.",
-    "manual_session_execution_allowed": false
+    "runtime_activation_handoff": "StegVerse-Labs/.github/handoffs/SHWP-DURABLE-RUNTIME-ACTIVATION.json#release-complete-housekeeping-only",
+    "execution_owner": "native resident WorkerCoordinator under independent task control",
+    "next_executable_action": "Consume RESIDENT-EXEC-HEALER-SOVEREIGN-SCHEDULER-001 through the native resident request sweep; acquire a fresh independent WorkerCoordinator admission/claim/fence; persist the no-token scheduler receipt; continue fail-closed target reconciliation. Do not wait on G18 terminalization.",
+    "manual_session_execution_allowed": false,
+    "g18_terminalization_required": false
   },
   "archive_dependency": false,
   "propagation_after_activation": [

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -12,7 +12,7 @@ credential_authority: TV/TVC
 non_tv_tvc_secret_or_token_allowed: false
 github_token_production_authority: NONE
 github_actions_production_role: NONE
-heartbeat_owner: StegVerse-Labs/.github G18
+heartbeat_owner: StegVerse-Labs/.github independent oscillator reference; G18 not downstream scheduler gate
 ordinary_scheduler_owner: SHWP-HEALER-SOVEREIGN-SCHEDULER-001
 wallet_signing_and_broadcast: USER_ONLY
 state: SOURCE_CONTROL_RELEASED_LIVE_SCHEDULER_ACTIVATION_MACHINE_OWNED
@@ -237,7 +237,7 @@ Canonical machine handoff:
 
 `StegVerse-Labs/.github/handoffs/SHWP-HEALER-SOVEREIGN-SCHEDULER-001.json`
 
-Current scheduler task state remains `HANDOFF_READY`, executor `AUTHORIZED`, worker available. The scheduler depends on `SHWP-DURABLE-RUNTIME-ACTIVATION`.
+Current scheduler task state remains `HANDOFF_READY`, executor `AUTHORIZED`, worker available. The scheduler is independently admitted and does not depend on G18 terminalization or `SHWP-DURABLE-RUNTIME-ACTIVATION` as a downstream gate.
 
 The upstream physical heartbeat handoff `StegVerse-Labs/.github/handoffs/SHWP-IPHONE-HB30-INLINE-CAPSULE-002.json` is source-released but remains at `HUMAN_PHYSICAL_EXECUTION_BOUNDARY` / `PHYSICAL_RECEIPT_NOT_YET_OBSERVED` on the current iPhone. No credential is required for that physical step; G18 and WorkerCoordinator own subsequent materialization and observation.
 
@@ -283,3 +283,21 @@ TVC PR #173 merged as `e8813e81494deb8e8563763675b5123e360397e6`, supplying the 
 Healer PR #42 merged as `a60e9d6717b4784591dffca8147b0b4afda2d468` with Test Readiness `33118760520 SUCCESS`, requiring canonical decision schema, receipt digest and SHA-256 policy/decision bindings before local StegDeploy execution.
 
 This closes the remaining source dependency for the Gateway scheduler target. Runtime execution, loopback readiness, public HTTPS route, TVC recipient liveness and owner ingress remain separate unobserved predicates.
+
+## 2026-08-31 resident scheduler gate correction
+
+The current organization handoff and `.github` PR #707 supersede older Healer prose that treated `SHWP-DURABLE-RUNTIME-ACTIVATION` / G18 as an upstream scheduler dependency.
+
+Current machine path:
+
+```text
+native resident WorkerCoordinator
+-> local canonical source refresh
+-> resident request sweep
+-> RESIDENT-EXEC-HEALER-SOVEREIGN-SCHEDULER-001
+-> fresh independent task admission / claim / fence
+-> fixed Healer handlers
+-> no-token scheduler receipt
+```
+
+G18/fence18 is retained only as stale housekeeping in the durable-runtime lane and must not delay the Healer scheduler. The next required goal is authentic resident consumption of the existing Healer request and production of the scheduler receipt.

--- a/docs/SITE_ERL_SOVEREIGN_SYNC_MIRROR_HANDOFF.md
+++ b/docs/SITE_ERL_SOVEREIGN_SYNC_MIRROR_HANDOFF.md
@@ -84,7 +84,7 @@ At this handoff revision that required scheduler receipt is absent. Therefore th
 
 Heartbeat activation is already terminal and the historical HB30 iPhone capsule is satisfied/superseded. There is no current iPhone action required for this ERL migration.
 
-The scheduler's unresolved dependency is the separate machine-owned `SHWP-DURABLE-RUNTIME-ACTIVATION` substrate, currently blocked because no eligible StegVerse-owned/federated sovereign node declaration is present. The existing scheduler lane must consume that runtime when available; no second scheduler or hosted substitute is authorized.
+The former `SHWP-DURABLE-RUNTIME-ACTIVATION` / G18 dependency is superseded as a downstream gate. The existing scheduler lane is independently admitted on the native resident WorkerCoordinator and must consume `RESIDENT-EXEC-HEALER-SOVEREIGN-SCHEDULER-001` under its own fresh claim/fence. No second scheduler or hosted substitute is authorized.
 
 ## Site retirement gate
 

--- a/tests/test_g18_gate_retirement.py
+++ b/tests/test_g18_gate_retirement.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class G18GateRetirementTests(unittest.TestCase):
+    def test_current_machine_continuation_uses_independent_resident_task_control(self):
+        state = json.loads(
+            (ROOT / "data/session_consolidation/tv-tvc-no-github-token-dispatch-migration.json").read_text()
+        )
+        continuation = state["canonical_machine_continuation"]
+        self.assertFalse(continuation["g18_terminalization_required"])
+        self.assertIn("native resident WorkerCoordinator", continuation["execution_owner"])
+        self.assertIn("RESIDENT-EXEC-HEALER-SOVEREIGN-SCHEDULER-001", continuation["next_executable_action"])
+        self.assertIn("Do not wait on G18 terminalization", continuation["next_executable_action"])
+
+    def test_current_handoff_does_not_state_scheduler_depends_on_durable_runtime(self):
+        handoff = (ROOT / "docs/HEALER_MIRROR_HANDOFF.md").read_text()
+        self.assertIn("does not depend on G18 terminalization", handoff)
+        self.assertIn("resident scheduler gate correction", handoff)
+        self.assertNotIn(
+            "The scheduler depends on `SHWP-DURABLE-RUNTIME-ACTIVATION`.",
+            handoff,
+        )
+
+    def test_erl_handoff_uses_same_independent_scheduler_semantics(self):
+        handoff = (ROOT / "docs/SITE_ERL_SOVEREIGN_SYNC_MIRROR_HANDOFF.md").read_text()
+        self.assertIn("superseded as a downstream gate", handoff)
+        self.assertIn("RESIDENT-EXEC-HEALER-SOVEREIGN-SCHEDULER-001", handoff)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Current runtime correction

The canonical .github runtime now marks G18/fence18 as stale housekeeping and not a downstream admission gate. Healer documentation still described the scheduler and ERL target as blocked on SHWP-DURABLE-RUNTIME-ACTIVATION.

This PR:
- rebinds the current Healer scheduler continuation to the native resident WorkerCoordinator under independent task control
- makes RESIDENT-EXEC-HEALER-SOVEREIGN-SCHEDULER-001 the next execution target
- removes stale G18 dependency language from the ERL continuation
- updates the machine continuation record
- adds a regression guard

No new scheduler, heartbeat, credential authority, or hosted execution path is introduced. The next required goal is authentic resident request consumption and a persisted no-token scheduler receipt.