### PR TITLE
Adopt StegVerse ecosystem purpose contribution contract

### DIFF
--- a/.stegverse/ecosystem-purpose-contribution.json
+++ b/.stegverse/ecosystem-purpose-contribution.json
@@ -1,0 +1,21 @@
+{
+  "schema": "stegverse.ecosystem-purpose-contribution/v1",
+  "repository": "StegVerse-Labs/StegVerse-Healer",
+  "adopted": "2026-09-02",
+  "canonical_invariant": "StegVerse-Labs/.github:control/ecosystem-purpose-invariant.json",
+  "contribution_classes": [
+    "observability",
+    "recovery",
+    "evidence"
+  ],
+  "authority_held": "UNCHANGED_FROM_REPOSITORY_LOCAL_HANDOFF",
+  "authority_not_held": "NO_NEW_AUTHORITY_GRANTED_BY_PURPOSE_INVARIANT",
+  "lifecycle_states_established": "UNCHANGED_FROM_REPOSITORY_LOCAL_EVIDENCE",
+  "evidence_outputs": "AS_DEFINED_BY_REPOSITORY_LOCAL_HANDOFF_AND_IMPLEMENTATION",
+  "upstream_interfaces": "AS_DEFINED_BY_REPOSITORY_LOCAL_HANDOFF",
+  "downstream_interfaces": "AS_DEFINED_BY_REPOSITORY_LOCAL_HANDOFF",
+  "consequence_boundary": "UNCHANGED_FROM_REPOSITORY_LOCAL_HANDOFF",
+  "maturity_gate": "NOT_ESTABLISHED_BY_PURPOSE_ADOPTION",
+  "intelligence_provider_independence": "PREFERRED_WHERE_ARCHITECTURALLY_APPLICABLE",
+  "runtime_activation_claim": false
+}

--- a/docs/HEALER_MIRROR_HANDOFF.md
+++ b/docs/HEALER_MIRROR_HANDOFF.md
@@ -319,3 +319,15 @@ unique canonical local StegVerse-Healer tree + canonical local repository map di
 Canonical search locations are local-only and perform no clone/fetch/pull. Missing or ambiguous Healer source remains BLOCKED. The heartbeat carrier receives none of these repository locators.
 
 This removes declaration-only source-root blockers from the resident scheduler path. The next required goal remains authentic consumption of `RESIDENT-EXEC-HEALER-SOVEREIGN-SCHEDULER-001` and production of the no-token scheduler/Gateway receipts.
+
+
+## Ecosystem purpose contribution — 2026-09-02
+
+Canonical organization invariant: `StegVerse-Labs/.github/docs/ECOSYSTEM_PURPOSE_INVARIANT.md`.
+Machine declaration: `.stegverse/ecosystem-purpose-contribution.json`.
+
+This repository contributes to the StegVerse ecosystem sum through: **observability, recovery, evidence**.
+
+This binding grants no new authority, does not change repository-local execution/credential/admission/routing/custody/publication/consequence boundaries, and does not establish a new runtime or maturity state. Existing handoff evidence remains authoritative for what this repository has actually implemented, validated, released, deployed, activated, observed, or reconstructed.
+
+The repository should continue advancing the shared objective: preserve agency and explicit authority while making consequential transitions bounded and reconstructable, without requiring a specific intelligence provider or collapsing governance into a universal correctness authority.


### PR DESCRIPTION
Adopts the canonical ecosystem purpose invariant merged in StegVerse-Labs/.github#847.

Adds `.stegverse/ecosystem-purpose-contribution.json` and binds the repository's canonical mirror handoff to the shared purpose.

This change grants no new authority, establishes no new runtime activation, and does not advance a maturity gate by documentation alone.