### PR TITLE
Schedule reusable native email monitor hourly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Healer dispatch does not itself grant provider execution, deployment, custody, p
 ## Current capabilities
 
 - Central hourly scheduler driven by `data/orchestrator_targets.json`.
+- Data-driven reusable-task scheduling through `data/reusable_task_schedule.json` inside that same sovereign scheduler path; schedule slots are receipt-idempotent so an hourly reusable task runs at most once per UTC hour.
+- `RT-NATIVE-EMAIL-ACTION-MONITOR-001` is scheduled hourly through the existing reusable-task trigger and canonical `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` path; no second mailbox monitor or scheduler is created.
 - Unauthorized downstream schedule auditing.
 - Configured cross-repository workflow dispatch.
 - YAML correction and reusable repair workflows.
@@ -24,8 +26,9 @@ Read these before modifying scheduling or dispatch behavior:
 - `docs/HEALER_MIRROR_HANDOFF.md`
 - `docs/HEALER_ACTIVATION_PLAN.md`
 - `data/orchestrator_targets.json`
+- `data/reusable_task_schedule.json`
 - `data/summary/single_scheduler_migration.json`
 
 ## Validation
 
-Repository validation is performed by the `Test Readiness` workflow. Runtime activation claims require observed GitHub Actions evidence and retained receipts; configuration alone is not activation proof.
+Repository validation is performed by the `Test Readiness` workflow. Runtime activation claims require observed resident/runtime evidence and retained receipts; configuration or source merge alone is not activation proof.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Healer dispatch does not itself grant provider execution, deployment, custody, p
 Read these before modifying scheduling or dispatch behavior:
 
 - `docs/HEALER_MIRROR_HANDOFF.md`
+- `docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md`
 - `docs/HEALER_ACTIVATION_PLAN.md`
 - `data/orchestrator_targets.json`
 - `data/reusable_task_schedule.json`

--- a/app/dispatch_orchestrators.py
+++ b/app/dispatch_orchestrators.py
@@ -6,9 +6,13 @@ Historical versions of this module called the GitHub workflow-dispatch API with
 HEALER_GH_TOKEN. That production transport is retired. Scheduling/execution is
 now carried by the single StegVerse resident heartbeat against already
 materialized repositories, with TV/TVC as credential/admission authority.
+
+Reusable-task schedules are evaluated inside that same scheduler path through
+`reusable_task_scheduler`; no second scheduler, polling loop, or credential route
+is introduced.
 """
 
-from sovereign_scheduler import main
+from reusable_task_scheduler import main
 
 
 if __name__ == "__main__":

--- a/app/reusable_task_scheduler.py
+++ b/app/reusable_task_scheduler.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+"""Extend the existing sovereign Healer scheduler with reusable-task schedules.
+
+This module is not a second scheduler. It is the single Healer scheduler entrypoint
+with an additional data-driven reusable-task schedule pass. Each schedule slot is
+idempotent by invocation id + retained local receipt, so an hourly entry runs at
+most once per UTC hour even if the resident scheduler is visited repeatedly.
+"""
+
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+import sovereign_scheduler as base
+
+SCHEDULE_FILE = Path(__file__).resolve().parents[1] / "data" / "reusable_task_schedule.json"
+
+
+def _load_schedule(path: Path) -> list[dict[str, Any]]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or value.get("schema") != "stegverse.healer.reusable-task-schedule/v1":
+        raise ValueError("reusable task schedule schema mismatch")
+    tasks = value.get("tasks")
+    if not isinstance(tasks, list) or not all(isinstance(row, dict) for row in tasks):
+        raise ValueError("reusable task schedule tasks must be objects")
+    return tasks
+
+
+def _selected(task: dict[str, Any], scope: str) -> bool:
+    if scope == "all":
+        return True
+    identity = str(task.get("reusable_task_id") or "").lower()
+    repo = str(task.get("repository") or "").split("/")[-1].lower()
+    aliases = {str(value).lower() for value in task.get("aliases", [])}
+    return scope in {identity, repo} or scope in aliases
+
+
+def _slot_id(task_id: str, now) -> str:
+    compact = task_id.replace("RT-", "rt-").lower()
+    return f"{compact}-{now.strftime('%Y%m%dT%H')}Z"
+
+
+def _execute_reusable_task(task: dict[str, Any], roots: dict[str, Path], roots_json: str, now) -> dict[str, Any]:
+    reusable_task_id = str(task.get("reusable_task_id") or "")
+    tracking_task_id = str(task.get("tracking_task_id") or "")
+    cosv = str(task.get("cosv_task_vector") or "")
+    repository = str(task.get("repository") or "")
+    base_result = {
+        "reusable_task_id": reusable_task_id,
+        "tracking_task_id": tracking_task_id,
+        "cosv_task_vector": cosv,
+        "repository": repository,
+    }
+
+    root = roots.get(repository)
+    if root is None:
+        return {**base_result, "state": "BLOCKED", "outcome": "LOCAL_REPOSITORY_NOT_MATERIALIZED"}
+    trigger = root / "scripts" / "trigger_reusable_task.py"
+    if not trigger.is_file():
+        return {**base_result, "state": "BLOCKED", "outcome": "REUSABLE_TASK_TRIGGER_NOT_MATERIALIZED"}
+
+    invocation_id = _slot_id(reusable_task_id, now)
+    receipt_path = root / "receipts" / "reusable-task" / f"{invocation_id}.latest.json"
+    if receipt_path.is_file():
+        prior = base._load_json(receipt_path)
+        return {
+            **base_result,
+            "state": "COMPLETE",
+            "outcome": "ALREADY_RAN_THIS_SCHEDULE_SLOT",
+            "invocation_id": invocation_id,
+            "receipt_ref": str(receipt_path),
+            "receipt_state": prior.get("state"),
+        }
+
+    parameters = dict(task.get("parameters") or {})
+    parameters["source_root"] = str(root)
+    parameters["runtime_root"] = str(root)
+    command = [
+        sys.executable,
+        str(trigger),
+        "--reusable-task-id",
+        reusable_task_id,
+        "--invocation-id",
+        invocation_id,
+        "--parameters-json",
+        json.dumps(parameters, sort_keys=True, separators=(",", ":")),
+        "--task-id",
+        tracking_task_id,
+        "--cosv-task-vector",
+        cosv,
+        "--receipt",
+        str(receipt_path),
+    ]
+    result = base._run(
+        command,
+        root,
+        {"STEGVERSE_REPO_ROOTS_JSON": roots_json},
+        timeout=1500,
+    )
+    receipt = base._load_json(receipt_path) if receipt_path.is_file() else None
+    ok = result["returncode"] == 0 and isinstance(receipt, dict)
+    return {
+        **base_result,
+        "state": "COMPLETE" if ok else "BLOCKED",
+        "outcome": "REUSABLE_TASK_SCHEDULE_SLOT_EXECUTED" if ok else "REUSABLE_TASK_SCHEDULE_SLOT_BLOCKED",
+        "invocation_id": invocation_id,
+        "receipt_ref": str(receipt_path),
+        "receipt_state": receipt.get("state") if isinstance(receipt, dict) else None,
+        "execution": result,
+    }
+
+
+def build_and_execute(config_path: Path, schedule_path: Path = SCHEDULE_FILE) -> dict[str, Any]:
+    receipt = base.build_and_execute(config_path)
+    roots = base._repo_roots()
+    roots_json = json.dumps({repo: str(path) for repo, path in sorted(roots.items())}, sort_keys=True)
+    scope = (os.getenv("RUN_SCOPE") or "all").strip().lower()
+    mode = (os.getenv("DISPATCH_MODE") or "schedule").strip().lower()
+    now = base._now()
+
+    scheduled: list[dict[str, Any]] = []
+    if schedule_path.is_file():
+        for task in _load_schedule(schedule_path):
+            if not task.get("enabled", True) or not _selected(task, scope):
+                continue
+            if not base._due(task, now, mode):
+                continue
+            scheduled.append(_execute_reusable_task(task, roots, roots_json, now))
+
+    receipt["reusable_task_schedule_schema"] = "stegverse.healer.reusable-task-schedule/v1"
+    receipt["selected_reusable_tasks"] = len(scheduled)
+    receipt["reusable_task_schedule"] = scheduled
+    if receipt.get("state") == "COMPLETE" and any(row.get("state") == "BLOCKED" for row in scheduled):
+        receipt["state"] = "BLOCKED"
+    return receipt
+
+
+def main() -> int:
+    config_path = Path(os.getenv("TARGETS_FILE", "data/orchestrator_targets.json")).resolve()
+    schedule_path = Path(os.getenv("REUSABLE_TASK_SCHEDULE_FILE", str(SCHEDULE_FILE))).resolve()
+    try:
+        receipt = build_and_execute(config_path, schedule_path)
+    except Exception as exc:
+        receipt = {
+            "schema": "stegverse.healer.sovereign_scheduler_receipt/v0.1",
+            "state": "FAILED",
+            "credential_authority": "TV/TVC",
+            "github_token_required": False,
+            "error": str(exc),
+        }
+    print(json.dumps(receipt, sort_keys=True))
+    return 0 if receipt["state"] == "COMPLETE" else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/reusable_task_schedule.json
+++ b/data/reusable_task_schedule.json
@@ -1,0 +1,19 @@
+{
+  "schema": "stegverse.healer.reusable-task-schedule/v1",
+  "tasks": [
+    {
+      "reusable_task_id": "RT-NATIVE-EMAIL-ACTION-MONITOR-001",
+      "tracking_task_id": "STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001",
+      "cosv_task_vector": "10100000100000",
+      "repository": "StegVerse-Labs/.github",
+      "enabled": true,
+      "aliases": ["native-email", "github-mail", "email-monitor"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "parameters": {
+        "bounded_mailbox_scope": "canonical GitHub/[Task Update] operational slice",
+        "observation_window": "since previous scheduled invocation"
+      },
+      "status": "hourly-existing-reusable-task-trigger-no-second-monitor-no-second-scheduler"
+    }
+  ]
+}

--- a/docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md
+++ b/docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md
@@ -1,0 +1,35 @@
+# Native Email Reusable Schedule Mirror Handoff
+
+Updated: 2026-09-09
+Repository: `StegVerse-Labs/StegVerse-Healer`
+Parent scheduler: `SHWP-HEALER-SOVEREIGN-SCHEDULER-001`
+Upstream task: `StegVerse-Labs/.github:STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001`
+Upstream COSV: `10100000100000`
+Upstream reusable identity: `RT-NATIVE-EMAIL-ACTION-MONITOR-001`
+Upstream scoped handoff: `StegVerse-Labs/.github:docs/NATIVE_EMAIL_REUSABLE_HOURLY_MIRROR_HANDOFF.md`
+
+## Purpose
+
+Schedule canonical reusable-task identities through the already-existing sovereign Healer scheduler. The first scheduled reusable identity is the native email action monitor, hourly, without introducing another scheduler, mailbox monitor, polling loop, heartbeat, WorkerCoordinator, or credential route.
+
+## Installed source
+
+- `data/reusable_task_schedule.json` — data-driven reusable-task schedule registry.
+- `app/reusable_task_scheduler.py` — extends the existing scheduler invocation with reusable-task slots.
+- `app/dispatch_orchestrators.py` — compatibility entrypoint now enters the extended scheduler path.
+- `tests/test_reusable_task_scheduler.py` — proves hourly binding and same-slot idempotency.
+- `README.md` — documents reusable-task scheduling responsibility and timer semantics.
+
+## Hourly contract
+
+`RT-NATIVE-EMAIL-ACTION-MONITOR-001` is eligible in every UTC hour. Its deterministic invocation id includes the UTC `YYYYMMDDTHH` slot. If the matching retained reusable-task receipt already exists, the scheduler records `ALREADY_RAN_THIS_SCHEDULE_SLOT` and does not invoke the task again.
+
+The schedule invokes `.github/scripts/trigger_reusable_task.py` using the existing tracking Task ID `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` and COSV `10100000100000`. The local `.github` repository root is bound as source/runtime root; `STEGVERSE_REPO_ROOTS_JSON` is passed so the existing consumer can resolve already-materialized TVC and StegOps provider-owner repositories.
+
+## Evidence boundary
+
+Source merge and deterministic tests prove schedule construction only. Authentic live hourly operation requires a retained runtime reusable-task receipt produced by the resident Healer scheduler. Provider authorization, mailbox access, corrective-task completion, and downstream execution retain their existing independent evidence predicates.
+
+## Current state
+
+Source implementation is on `feat/native-email-reusable-hourly-20260909`; validation/merge are pending. No live schedule receipt is claimed yet.

--- a/tests/test_reusable_task_scheduler.py
+++ b/tests/test_reusable_task_scheduler.py
@@ -49,7 +49,10 @@ class ReusableTaskSchedulerTests(unittest.TestCase):
                 }],
             }), encoding="utf-8")
 
-            with mock.patch.object(subject.base, "build_and_execute", return_value={"schema":"stegverse.healer.sovereign_scheduler_receipt/v0.1","state":"COMPLETE"}), \
+            def fresh_base_receipt(_config_path: Path) -> dict[str, object]:
+                return {"schema":"stegverse.healer.sovereign_scheduler_receipt/v0.1","state":"COMPLETE"}
+
+            with mock.patch.object(subject.base, "build_and_execute", side_effect=fresh_base_receipt), \
                  mock.patch.object(subject.base, "_repo_roots", return_value={"StegVerse-Labs/.github": github_root}), \
                  mock.patch.object(subject.base, "_now", return_value=now), \
                  mock.patch.dict("os.environ", {"RUN_SCOPE":"all","DISPATCH_MODE":"schedule"}, clear=False):

--- a/tests/test_reusable_task_scheduler.py
+++ b/tests/test_reusable_task_scheduler.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "app"
+if str(APP) not in sys.path:
+    sys.path.insert(0, str(APP))
+
+import reusable_task_scheduler as subject  # noqa: E402
+
+
+class ReusableTaskSchedulerTests(unittest.TestCase):
+    def test_hourly_slot_executes_once_then_reuses_receipt(self) -> None:
+        now = dt.datetime(2026, 9, 9, 9, 15, tzinfo=dt.timezone.utc)
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            github_root = tmp_root / ".github"
+            trigger = github_root / "scripts" / "trigger_reusable_task.py"
+            trigger.parent.mkdir(parents=True)
+            trigger.write_text(
+                "#!/usr/bin/env python3\n"
+                "import argparse,json\n"
+                "from pathlib import Path\n"
+                "p=argparse.ArgumentParser()\n"
+                "p.add_argument('--reusable-task-id');p.add_argument('--invocation-id');p.add_argument('--parameters-json');p.add_argument('--task-id');p.add_argument('--cosv-task-vector');p.add_argument('--receipt')\n"
+                "a=p.parse_args()\n"
+                "Path(a.receipt).parent.mkdir(parents=True,exist_ok=True)\n"
+                "Path(a.receipt).write_text(json.dumps({'schema':'stegverse.reusable-task-trigger-receipt/v1','state':'AUTOMATABLE_STEPS_EXHAUSTED','invocation_id':a.invocation_id})+'\\n')\n",
+                encoding="utf-8",
+            )
+            schedule = tmp_root / "schedule.json"
+            schedule.write_text(json.dumps({
+                "schema": "stegverse.healer.reusable-task-schedule/v1",
+                "tasks": [{
+                    "reusable_task_id": "RT-NATIVE-EMAIL-ACTION-MONITOR-001",
+                    "tracking_task_id": "STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001",
+                    "cosv_task_vector": "10100000100000",
+                    "repository": "StegVerse-Labs/.github",
+                    "enabled": True,
+                    "run_hours_utc": list(range(24)),
+                    "parameters": {"bounded_mailbox_scope": "github"},
+                }],
+            }), encoding="utf-8")
+
+            with mock.patch.object(subject.base, "build_and_execute", return_value={"schema":"stegverse.healer.sovereign_scheduler_receipt/v0.1","state":"COMPLETE"}), \
+                 mock.patch.object(subject.base, "_repo_roots", return_value={"StegVerse-Labs/.github": github_root}), \
+                 mock.patch.object(subject.base, "_now", return_value=now), \
+                 mock.patch.dict("os.environ", {"RUN_SCOPE":"all","DISPATCH_MODE":"schedule"}, clear=False):
+                first = subject.build_and_execute(tmp_root / "targets.json", schedule)
+                second = subject.build_and_execute(tmp_root / "targets.json", schedule)
+
+            self.assertEqual(first["state"], "COMPLETE")
+            self.assertEqual(first["selected_reusable_tasks"], 1)
+            first_row = first["reusable_task_schedule"][0]
+            self.assertEqual(first_row["outcome"], "REUSABLE_TASK_SCHEDULE_SLOT_EXECUTED")
+            self.assertEqual(first_row["invocation_id"], "rt-native-email-action-monitor-001-20260909T09Z")
+            self.assertTrue(Path(first_row["receipt_ref"]).is_file())
+
+            second_row = second["reusable_task_schedule"][0]
+            self.assertEqual(second_row["outcome"], "ALREADY_RAN_THIS_SCHEDULE_SLOT")
+            self.assertEqual(second_row["invocation_id"], first_row["invocation_id"])
+
+    def test_config_binds_email_monitor_every_utc_hour(self) -> None:
+        config = json.loads((ROOT / "data" / "reusable_task_schedule.json").read_text(encoding="utf-8"))
+        rows = [row for row in config["tasks"] if row["reusable_task_id"] == "RT-NATIVE-EMAIL-ACTION-MONITOR-001"]
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["tracking_task_id"], "STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001")
+        self.assertEqual(row["cosv_task_vector"], "10100000100000")
+        self.assertEqual(row["run_hours_utc"], list(range(24)))
+        self.assertTrue(row["enabled"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal
Bind the existing `RT-NATIVE-EMAIL-ACTION-MONITOR-001` / `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` (`10100000100000`) to an hourly timer through the already-existing sovereign Healer scheduler.

## Changes
- add `data/reusable_task_schedule.json` as a data-driven reusable-task schedule registry;
- add `app/reusable_task_scheduler.py` to extend the existing scheduler pass rather than creating a second scheduler;
- use deterministic UTC-hour invocation IDs plus retained receipts for at-most-once execution per hour slot;
- route the compatibility scheduler entrypoint through that extended path;
- add deterministic tests for hourly binding and same-slot idempotency;
- update `README.md` and add `docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md`.

## Boundaries
No new mailbox monitor, heartbeat, WorkerCoordinator, polling loop, provider credential route, or GitHub-token production authority. The scheduled pass invokes the existing reusable-task trigger in the already-materialized `.github` repository and preserves downstream TV/TVC/provider/runtime evidence boundaries.

## Coordinated dependency
Requires the companion `.github` change that makes the reusable trigger pass required source/runtime roots to the existing native-email consumer.

Live hourly execution remains unclaimed until an authentic resident schedule receipt is retained.