### PR TITLE
Bind hourly reusable email task to resident runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Healer dispatch does not itself grant provider execution, deployment, custody, p
 
 - Central hourly scheduler driven by `data/orchestrator_targets.json`.
 - Data-driven reusable-task scheduling through `data/reusable_task_schedule.json` inside that same sovereign scheduler path; schedule slots are receipt-idempotent so an hourly reusable task runs at most once per UTC hour.
+- Scheduled reusable tasks keep source and resident runtime distinct: task source comes from the already-materialized local repository map, execution state and reusable-task receipts live under the resident runtime identified by `STEGVERSE_HEARTBEAT_ROOT`, and a missing resident runtime blocks rather than falling back to the source checkout.
 - `RT-NATIVE-EMAIL-ACTION-MONITOR-001` is scheduled hourly through the existing reusable-task trigger and canonical `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` path; no second mailbox monitor or scheduler is created.
 - Unauthorized downstream schedule auditing.
 - Configured cross-repository workflow dispatch.

--- a/app/reusable_task_scheduler.py
+++ b/app/reusable_task_scheduler.py
@@ -18,6 +18,7 @@ import sovereign_scheduler as base
 
 SCHEDULE_FILE = Path(__file__).resolve().parents[1] / "data" / "reusable_task_schedule.json"
 RUNTIME_ROOT_ENV = "STEGVERSE_HEARTBEAT_ROOT"
+RUNTIME_REQUIRED_REL = Path("control/resident-execution-request.d/native-email-action-monitor-001.json")
 
 
 def _load_schedule(path: Path) -> list[dict[str, Any]]:
@@ -44,12 +45,38 @@ def _slot_id(task_id: str, now) -> str:
     return f"{compact}-{now.strftime('%Y%m%dT%H')}Z"
 
 
-def _resident_runtime_root() -> Path | None:
+def _valid_runtime_root(root: Path) -> bool:
+    return root.is_dir() and (root / RUNTIME_REQUIRED_REL).is_file()
+
+
+def _resident_runtime_root() -> tuple[Path | None, str]:
     raw = str(os.getenv(RUNTIME_ROOT_ENV) or "").strip()
-    if not raw:
-        return None
-    root = Path(raw).expanduser().resolve()
-    return root if root.is_dir() else None
+    if raw:
+        root = Path(raw).expanduser().resolve()
+        return (root, "EXPLICIT_NONSECRET_RUNTIME_ROOT") if _valid_runtime_root(root) else (None, "EXPLICIT_RUNTIME_ROOT_INVALID")
+
+    home = Path.home()
+    candidates = [
+        home / ".local" / "state" / "stegverse" / "heartbeat-runtime",
+        home / "Library" / "Application Support" / "stegverse" / "heartbeat-runtime",
+        home / ".stegverse" / "heartbeat-runtime",
+        Path("/var/lib/stegverse/heartbeat-runtime"),
+        Path("/srv/stegverse/heartbeat-runtime"),
+    ]
+    valid = []
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except Exception:
+            continue
+        if _valid_runtime_root(resolved):
+            valid.append(resolved)
+    unique = list(dict.fromkeys(str(path) for path in valid))
+    if len(unique) == 1:
+        return Path(unique[0]), "CANONICAL_LOCAL_RUNTIME_DISCOVERY"
+    if len(unique) > 1:
+        return None, "CANONICAL_RUNTIME_AMBIGUOUS"
+    return None, "CANONICAL_RUNTIME_NOT_FOUND"
 
 
 def _execute_reusable_task(
@@ -57,6 +84,7 @@ def _execute_reusable_task(
     roots: dict[str, Path],
     roots_json: str,
     runtime_root: Path | None,
+    runtime_root_source: str,
     now,
 ) -> dict[str, Any]:
     reusable_task_id = str(task.get("reusable_task_id") or "")
@@ -68,6 +96,7 @@ def _execute_reusable_task(
         "tracking_task_id": tracking_task_id,
         "cosv_task_vector": cosv,
         "repository": repository,
+        "runtime_root_source": runtime_root_source,
     }
 
     root = roots.get(repository)
@@ -144,7 +173,7 @@ def build_and_execute(config_path: Path, schedule_path: Path = SCHEDULE_FILE) ->
     scope = (os.getenv("RUN_SCOPE") or "all").strip().lower()
     mode = (os.getenv("DISPATCH_MODE") or "schedule").strip().lower()
     now = base._now()
-    runtime_root = _resident_runtime_root()
+    runtime_root, runtime_root_source = _resident_runtime_root()
 
     scheduled: list[dict[str, Any]] = []
     if schedule_path.is_file():
@@ -153,12 +182,13 @@ def build_and_execute(config_path: Path, schedule_path: Path = SCHEDULE_FILE) ->
                 continue
             if not base._due(task, now, mode):
                 continue
-            scheduled.append(_execute_reusable_task(task, roots, roots_json, runtime_root, now))
+            scheduled.append(_execute_reusable_task(task, roots, roots_json, runtime_root, runtime_root_source, now))
 
     receipt["reusable_task_schedule_schema"] = "stegverse.healer.reusable-task-schedule/v1"
     receipt["selected_reusable_tasks"] = len(scheduled)
     receipt["reusable_task_schedule"] = scheduled
     receipt["resident_runtime_root"] = str(runtime_root) if runtime_root is not None else None
+    receipt["resident_runtime_root_source"] = runtime_root_source
     if receipt.get("state") == "COMPLETE" and any(row.get("state") == "BLOCKED" for row in scheduled):
         receipt["state"] = "BLOCKED"
     return receipt

--- a/app/reusable_task_scheduler.py
+++ b/app/reusable_task_scheduler.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 This module is not a second scheduler. It is the single Healer scheduler entrypoint
 with an additional data-driven reusable-task schedule pass. Each schedule slot is
-idempotent by invocation id + retained local receipt, so an hourly entry runs at
-most once per UTC hour even if the resident scheduler is visited repeatedly.
+idempotent by invocation id + retained resident-runtime receipt, so an hourly entry
+runs at most once per UTC hour even if the resident scheduler is visited repeatedly.
 """
 
 import json
@@ -17,6 +17,7 @@ from typing import Any
 import sovereign_scheduler as base
 
 SCHEDULE_FILE = Path(__file__).resolve().parents[1] / "data" / "reusable_task_schedule.json"
+RUNTIME_ROOT_ENV = "STEGVERSE_HEARTBEAT_ROOT"
 
 
 def _load_schedule(path: Path) -> list[dict[str, Any]]:
@@ -43,7 +44,21 @@ def _slot_id(task_id: str, now) -> str:
     return f"{compact}-{now.strftime('%Y%m%dT%H')}Z"
 
 
-def _execute_reusable_task(task: dict[str, Any], roots: dict[str, Path], roots_json: str, now) -> dict[str, Any]:
+def _resident_runtime_root() -> Path | None:
+    raw = str(os.getenv(RUNTIME_ROOT_ENV) or "").strip()
+    if not raw:
+        return None
+    root = Path(raw).expanduser().resolve()
+    return root if root.is_dir() else None
+
+
+def _execute_reusable_task(
+    task: dict[str, Any],
+    roots: dict[str, Path],
+    roots_json: str,
+    runtime_root: Path | None,
+    now,
+) -> dict[str, Any]:
     reusable_task_id = str(task.get("reusable_task_id") or "")
     tracking_task_id = str(task.get("tracking_task_id") or "")
     cosv = str(task.get("cosv_task_vector") or "")
@@ -58,12 +73,14 @@ def _execute_reusable_task(task: dict[str, Any], roots: dict[str, Path], roots_j
     root = roots.get(repository)
     if root is None:
         return {**base_result, "state": "BLOCKED", "outcome": "LOCAL_REPOSITORY_NOT_MATERIALIZED"}
+    if runtime_root is None:
+        return {**base_result, "state": "BLOCKED", "outcome": "RESIDENT_RUNTIME_ROOT_NOT_MATERIALIZED"}
     trigger = root / "scripts" / "trigger_reusable_task.py"
     if not trigger.is_file():
         return {**base_result, "state": "BLOCKED", "outcome": "REUSABLE_TASK_TRIGGER_NOT_MATERIALIZED"}
 
     invocation_id = _slot_id(reusable_task_id, now)
-    receipt_path = root / "receipts" / "reusable-task" / f"{invocation_id}.latest.json"
+    receipt_path = runtime_root / "receipts" / "reusable-task" / f"{invocation_id}.latest.json"
     if receipt_path.is_file():
         prior = base._load_json(receipt_path)
         return {
@@ -73,11 +90,13 @@ def _execute_reusable_task(task: dict[str, Any], roots: dict[str, Path], roots_j
             "invocation_id": invocation_id,
             "receipt_ref": str(receipt_path),
             "receipt_state": prior.get("state"),
+            "source_root": str(root),
+            "runtime_root": str(runtime_root),
         }
 
     parameters = dict(task.get("parameters") or {})
     parameters["source_root"] = str(root)
-    parameters["runtime_root"] = str(root)
+    parameters["runtime_root"] = str(runtime_root)
     command = [
         sys.executable,
         str(trigger),
@@ -97,7 +116,10 @@ def _execute_reusable_task(task: dict[str, Any], roots: dict[str, Path], roots_j
     result = base._run(
         command,
         root,
-        {"STEGVERSE_REPO_ROOTS_JSON": roots_json},
+        {
+            "STEGVERSE_REPO_ROOTS_JSON": roots_json,
+            RUNTIME_ROOT_ENV: str(runtime_root),
+        },
         timeout=1500,
     )
     receipt = base._load_json(receipt_path) if receipt_path.is_file() else None
@@ -109,6 +131,8 @@ def _execute_reusable_task(task: dict[str, Any], roots: dict[str, Path], roots_j
         "invocation_id": invocation_id,
         "receipt_ref": str(receipt_path),
         "receipt_state": receipt.get("state") if isinstance(receipt, dict) else None,
+        "source_root": str(root),
+        "runtime_root": str(runtime_root),
         "execution": result,
     }
 
@@ -120,6 +144,7 @@ def build_and_execute(config_path: Path, schedule_path: Path = SCHEDULE_FILE) ->
     scope = (os.getenv("RUN_SCOPE") or "all").strip().lower()
     mode = (os.getenv("DISPATCH_MODE") or "schedule").strip().lower()
     now = base._now()
+    runtime_root = _resident_runtime_root()
 
     scheduled: list[dict[str, Any]] = []
     if schedule_path.is_file():
@@ -128,11 +153,12 @@ def build_and_execute(config_path: Path, schedule_path: Path = SCHEDULE_FILE) ->
                 continue
             if not base._due(task, now, mode):
                 continue
-            scheduled.append(_execute_reusable_task(task, roots, roots_json, now))
+            scheduled.append(_execute_reusable_task(task, roots, roots_json, runtime_root, now))
 
     receipt["reusable_task_schedule_schema"] = "stegverse.healer.reusable-task-schedule/v1"
     receipt["selected_reusable_tasks"] = len(scheduled)
     receipt["reusable_task_schedule"] = scheduled
+    receipt["resident_runtime_root"] = str(runtime_root) if runtime_root is not None else None
     if receipt.get("state") == "COMPLETE" and any(row.get("state") == "BLOCKED" for row in scheduled):
         receipt["state"] = "BLOCKED"
     return receipt

--- a/docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md
+++ b/docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md
@@ -9,7 +9,7 @@ Upstream reusable identity: `RT-NATIVE-EMAIL-ACTION-MONITOR-001`
 Upstream scoped handoff: `StegVerse-Labs/.github:docs/NATIVE_EMAIL_REUSABLE_HOURLY_MIRROR_HANDOFF.md`
 Source merge: PR `#57` / merge `ef5d90a8c215056e055385a04534e16c49d9a3d5`
 Upstream merge: `StegVerse-Labs/.github#1252` / merge `700f959dca0160f0d71d92fc391c9f262f27feea`
-State: `SOURCE_INTEGRATION_MERGED / HOURLY_SLOT_CONFIGURATION_MERGED / LIVE_SCHEDULE_RECEIPT_PENDING`
+State: `SOURCE_INTEGRATION_MERGED / HOURLY_SLOT_CONFIGURATION_MERGED / SOURCE_RUNTIME_COLLAPSE_REPAIR_IN_PROGRESS / LIVE_SCHEDULE_RECEIPT_PENDING`
 
 ## Purpose
 
@@ -20,21 +20,36 @@ Schedule canonical reusable-task identities through the already-existing soverei
 - `data/reusable_task_schedule.json` — data-driven reusable-task schedule registry.
 - `app/reusable_task_scheduler.py` — extends the existing scheduler invocation with reusable-task slots.
 - `app/dispatch_orchestrators.py` — compatibility entrypoint enters the extended scheduler path.
-- `tests/test_reusable_task_scheduler.py` — proves hourly binding and same-slot idempotency.
-- `README.md` — documents reusable-task scheduling responsibility and timer semantics.
+- `tests/test_reusable_task_scheduler.py` — proves hourly binding, resident-runtime separation, and same-slot idempotency.
+- `README.md` — documents reusable-task scheduling responsibility and resident-runtime semantics.
 
 ## Hourly contract
 
-`RT-NATIVE-EMAIL-ACTION-MONITOR-001` is eligible in every UTC hour. Its deterministic invocation id includes the UTC `YYYYMMDDTHH` slot. If the matching retained reusable-task receipt already exists, the scheduler records `ALREADY_RAN_THIS_SCHEDULE_SLOT` and does not invoke the task again.
+`RT-NATIVE-EMAIL-ACTION-MONITOR-001` is eligible in every UTC hour. Its deterministic invocation id includes the UTC `YYYYMMDDTHH` slot. If the matching retained reusable-task receipt already exists in the resident heartbeat runtime, the scheduler records `ALREADY_RAN_THIS_SCHEDULE_SLOT` and does not invoke the task again.
 
-The schedule invokes `.github/scripts/trigger_reusable_task.py` using the existing tracking Task ID `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` and COSV `10100000100000`. The local `.github` repository root is bound as source/runtime root; `STEGVERSE_REPO_ROOTS_JSON` is passed so the existing consumer can resolve already-materialized TVC and StegOps provider-owner repositories.
+The schedule invokes `.github/scripts/trigger_reusable_task.py` using the existing tracking Task ID `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` and COSV `10100000100000`. The local `.github` repository remains the source root. The resident heartbeat runtime supplied through `STEGVERSE_HEARTBEAT_ROOT` is the runtime root and receipt destination. The two roots must not collapse into the same source checkout. If the resident runtime is unavailable, the scheduled task fails closed with `RESIDENT_RUNTIME_ROOT_NOT_MATERIALIZED` instead of treating source as runtime.
 
-## Validation evidence
+`STEGVERSE_REPO_ROOTS_JSON` remains the nonsecret local repository map used by the existing native-email consumer to resolve already-materialized TVC and StegOps provider-owner repositories.
 
-PR #57 exact head `99e63e6e01962232125f70becec5e21eac11ae30` passed Test Readiness run `34332190725`. The earlier run `34332041418` exposed only a test-fixture aliasing defect: the mocked base scheduler returned the same mutable receipt object for two invocations, causing the first result to appear overwritten by the second same-slot result. The test was corrected to provide a fresh base receipt per invocation; scheduler production semantics were unchanged.
+## Defect repaired in current continuation
+
+The first merged hourly implementation passed the local `.github` source checkout as both `source_root` and `runtime_root`, and wrote reusable-task slot receipts under the source checkout. That topology could make a source tree appear to be the resident execution surface and was incompatible with the separated resident runtime model.
+
+The current repair:
+
+- resolves the runtime from `STEGVERSE_HEARTBEAT_ROOT`;
+- passes the local `.github` checkout only as `source_root`;
+- passes the resident heartbeat runtime only as `runtime_root`;
+- stores `receipts/reusable-task/<slot>.latest.json` under the resident runtime;
+- blocks rather than falling back when the resident runtime is absent;
+- retains same-UTC-hour idempotency using the resident receipt.
+
+## Prior validation evidence
+
+PR #57 exact head `99e63e6e01962232125f70becec5e21eac11ae30` passed Test Readiness run `34332190725`. The earlier run `34332041418` exposed only a test-fixture aliasing defect and was repaired without weakening scheduler production semantics.
 
 The coordinated `.github` PR #1252 exact head passed Heartbeat Worker Project run `34332023132`, organization-control run `34332023277`, and Deterministic Repository Suite run `34332023168` before merge.
 
 ## Evidence boundary
 
-Source integration, hourly schedule configuration, same-slot idempotency, tests, README maintenance, and both coordinated merges are complete. Authentic live hourly operation still requires a retained runtime reusable-task receipt produced by the resident Healer scheduler. Provider authorization, mailbox access, corrective-task completion, and downstream execution retain their existing independent evidence predicates.
+Reusable identity, hourly schedule construction, standing Healer resident recurrence, source/runtime separation, same-slot idempotency, and resident receipt placement must all be merged and validated before live execution is claimed. Authentic live hourly operation still requires a retained resident reusable-task receipt plus the corresponding native-email/TV-TVC Gmail provider evidence for a mailbox-processing claim.

--- a/tests/test_reusable_task_scheduler.py
+++ b/tests/test_reusable_task_scheduler.py
@@ -51,13 +51,19 @@ class ReusableTaskSchedulerTests(unittest.TestCase):
         )
         return github_root
 
+    def _runtime_root(self, path: Path) -> Path:
+        runtime_root = path
+        request = runtime_root / subject.RUNTIME_REQUIRED_REL
+        request.parent.mkdir(parents=True, exist_ok=True)
+        request.write_text("{}\n", encoding="utf-8")
+        return runtime_root
+
     def test_hourly_slot_executes_once_then_reuses_resident_receipt(self) -> None:
         now = dt.datetime(2026, 9, 9, 9, 15, tzinfo=dt.timezone.utc)
         with tempfile.TemporaryDirectory() as tmp:
             tmp_root = Path(tmp)
             github_root = self._github_root(tmp_root)
-            runtime_root = tmp_root / "heartbeat-runtime"
-            runtime_root.mkdir()
+            runtime_root = self._runtime_root(tmp_root / "heartbeat-runtime")
             schedule = tmp_root / "schedule.json"
             self._schedule(schedule)
 
@@ -78,6 +84,7 @@ class ReusableTaskSchedulerTests(unittest.TestCase):
             self.assertEqual(first["state"], "COMPLETE")
             self.assertEqual(first["selected_reusable_tasks"], 1)
             self.assertEqual(first["resident_runtime_root"], str(runtime_root.resolve()))
+            self.assertEqual(first["resident_runtime_root_source"], "EXPLICIT_NONSECRET_RUNTIME_ROOT")
             first_row = first["reusable_task_schedule"][0]
             self.assertEqual(first_row["outcome"], "REUSABLE_TASK_SCHEDULE_SLOT_EXECUTED")
             self.assertEqual(first_row["invocation_id"], "rt-native-email-action-monitor-001-20260909T09Z")
@@ -91,6 +98,16 @@ class ReusableTaskSchedulerTests(unittest.TestCase):
             self.assertEqual(second_row["outcome"], "ALREADY_RAN_THIS_SCHEDULE_SLOT")
             self.assertEqual(second_row["invocation_id"], first_row["invocation_id"])
 
+    def test_canonical_local_runtime_discovery_without_forwarded_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            runtime_root = self._runtime_root(home / ".local" / "state" / "stegverse" / "heartbeat-runtime")
+            with mock.patch.object(subject.Path, "home", return_value=home), \
+                 mock.patch.dict("os.environ", {"STEGVERSE_HEARTBEAT_ROOT": ""}, clear=False):
+                resolved, source = subject._resident_runtime_root()
+            self.assertEqual(resolved, runtime_root.resolve())
+            self.assertEqual(source, "CANONICAL_LOCAL_RUNTIME_DISCOVERY")
+
     def test_missing_resident_runtime_blocks_instead_of_using_source_as_runtime(self) -> None:
         now = dt.datetime(2026, 9, 9, 9, 15, tzinfo=dt.timezone.utc)
         with tempfile.TemporaryDirectory() as tmp:
@@ -102,6 +119,7 @@ class ReusableTaskSchedulerTests(unittest.TestCase):
             with mock.patch.object(subject.base, "build_and_execute", return_value={"schema":"stegverse.healer.sovereign_scheduler_receipt/v0.1","state":"COMPLETE"}), \
                  mock.patch.object(subject.base, "_repo_roots", return_value={"StegVerse-Labs/.github": github_root}), \
                  mock.patch.object(subject.base, "_now", return_value=now), \
+                 mock.patch.object(subject.Path, "home", return_value=tmp_root / "no-home-runtime"), \
                  mock.patch.dict("os.environ", {"RUN_SCOPE":"all","DISPATCH_MODE":"schedule","STEGVERSE_HEARTBEAT_ROOT":""}, clear=False):
                 result = subject.build_and_execute(tmp_root / "targets.json", schedule)
 
@@ -109,6 +127,7 @@ class ReusableTaskSchedulerTests(unittest.TestCase):
             row = result["reusable_task_schedule"][0]
             self.assertEqual(row["outcome"], "RESIDENT_RUNTIME_ROOT_NOT_MATERIALIZED")
             self.assertIsNone(result["resident_runtime_root"])
+            self.assertEqual(result["resident_runtime_root_source"], "CANONICAL_RUNTIME_NOT_FOUND")
 
     def test_config_binds_email_monitor_every_utc_hour(self) -> None:
         config = json.loads((ROOT / "data" / "reusable_task_schedule.json").read_text(encoding="utf-8"))

--- a/tests/test_reusable_task_scheduler.py
+++ b/tests/test_reusable_task_scheduler.py
@@ -17,37 +17,49 @@ import reusable_task_scheduler as subject  # noqa: E402
 
 
 class ReusableTaskSchedulerTests(unittest.TestCase):
-    def test_hourly_slot_executes_once_then_reuses_receipt(self) -> None:
+    def _schedule(self, path: Path) -> None:
+        path.write_text(json.dumps({
+            "schema": "stegverse.healer.reusable-task-schedule/v1",
+            "tasks": [{
+                "reusable_task_id": "RT-NATIVE-EMAIL-ACTION-MONITOR-001",
+                "tracking_task_id": "STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001",
+                "cosv_task_vector": "10100000100000",
+                "repository": "StegVerse-Labs/.github",
+                "enabled": True,
+                "run_hours_utc": list(range(24)),
+                "parameters": {"bounded_mailbox_scope": "github"},
+            }],
+        }), encoding="utf-8")
+
+    def _github_root(self, tmp_root: Path) -> Path:
+        github_root = tmp_root / ".github"
+        trigger = github_root / "scripts" / "trigger_reusable_task.py"
+        trigger.parent.mkdir(parents=True)
+        trigger.write_text(
+            "#!/usr/bin/env python3\n"
+            "import argparse,json\n"
+            "from pathlib import Path\n"
+            "p=argparse.ArgumentParser()\n"
+            "p.add_argument('--reusable-task-id');p.add_argument('--invocation-id');p.add_argument('--parameters-json');p.add_argument('--task-id');p.add_argument('--cosv-task-vector');p.add_argument('--receipt')\n"
+            "a=p.parse_args()\n"
+            "params=json.loads(a.parameters_json)\n"
+            "assert Path(params['source_root']).resolve()==Path.cwd().resolve()\n"
+            "assert Path(params['runtime_root']).resolve()!=Path.cwd().resolve()\n"
+            "Path(a.receipt).parent.mkdir(parents=True,exist_ok=True)\n"
+            "Path(a.receipt).write_text(json.dumps({'schema':'stegverse.reusable-task-trigger-receipt/v1','state':'AUTOMATABLE_STEPS_EXHAUSTED','invocation_id':a.invocation_id,'parameters':params})+'\\n')\n",
+            encoding="utf-8",
+        )
+        return github_root
+
+    def test_hourly_slot_executes_once_then_reuses_resident_receipt(self) -> None:
         now = dt.datetime(2026, 9, 9, 9, 15, tzinfo=dt.timezone.utc)
         with tempfile.TemporaryDirectory() as tmp:
             tmp_root = Path(tmp)
-            github_root = tmp_root / ".github"
-            trigger = github_root / "scripts" / "trigger_reusable_task.py"
-            trigger.parent.mkdir(parents=True)
-            trigger.write_text(
-                "#!/usr/bin/env python3\n"
-                "import argparse,json\n"
-                "from pathlib import Path\n"
-                "p=argparse.ArgumentParser()\n"
-                "p.add_argument('--reusable-task-id');p.add_argument('--invocation-id');p.add_argument('--parameters-json');p.add_argument('--task-id');p.add_argument('--cosv-task-vector');p.add_argument('--receipt')\n"
-                "a=p.parse_args()\n"
-                "Path(a.receipt).parent.mkdir(parents=True,exist_ok=True)\n"
-                "Path(a.receipt).write_text(json.dumps({'schema':'stegverse.reusable-task-trigger-receipt/v1','state':'AUTOMATABLE_STEPS_EXHAUSTED','invocation_id':a.invocation_id})+'\\n')\n",
-                encoding="utf-8",
-            )
+            github_root = self._github_root(tmp_root)
+            runtime_root = tmp_root / "heartbeat-runtime"
+            runtime_root.mkdir()
             schedule = tmp_root / "schedule.json"
-            schedule.write_text(json.dumps({
-                "schema": "stegverse.healer.reusable-task-schedule/v1",
-                "tasks": [{
-                    "reusable_task_id": "RT-NATIVE-EMAIL-ACTION-MONITOR-001",
-                    "tracking_task_id": "STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001",
-                    "cosv_task_vector": "10100000100000",
-                    "repository": "StegVerse-Labs/.github",
-                    "enabled": True,
-                    "run_hours_utc": list(range(24)),
-                    "parameters": {"bounded_mailbox_scope": "github"},
-                }],
-            }), encoding="utf-8")
+            self._schedule(schedule)
 
             def fresh_base_receipt(_config_path: Path) -> dict[str, object]:
                 return {"schema":"stegverse.healer.sovereign_scheduler_receipt/v0.1","state":"COMPLETE"}
@@ -55,20 +67,48 @@ class ReusableTaskSchedulerTests(unittest.TestCase):
             with mock.patch.object(subject.base, "build_and_execute", side_effect=fresh_base_receipt), \
                  mock.patch.object(subject.base, "_repo_roots", return_value={"StegVerse-Labs/.github": github_root}), \
                  mock.patch.object(subject.base, "_now", return_value=now), \
-                 mock.patch.dict("os.environ", {"RUN_SCOPE":"all","DISPATCH_MODE":"schedule"}, clear=False):
+                 mock.patch.dict("os.environ", {
+                     "RUN_SCOPE":"all",
+                     "DISPATCH_MODE":"schedule",
+                     "STEGVERSE_HEARTBEAT_ROOT": str(runtime_root),
+                 }, clear=False):
                 first = subject.build_and_execute(tmp_root / "targets.json", schedule)
                 second = subject.build_and_execute(tmp_root / "targets.json", schedule)
 
             self.assertEqual(first["state"], "COMPLETE")
             self.assertEqual(first["selected_reusable_tasks"], 1)
+            self.assertEqual(first["resident_runtime_root"], str(runtime_root.resolve()))
             first_row = first["reusable_task_schedule"][0]
             self.assertEqual(first_row["outcome"], "REUSABLE_TASK_SCHEDULE_SLOT_EXECUTED")
             self.assertEqual(first_row["invocation_id"], "rt-native-email-action-monitor-001-20260909T09Z")
-            self.assertTrue(Path(first_row["receipt_ref"]).is_file())
+            receipt = Path(first_row["receipt_ref"])
+            self.assertTrue(receipt.is_file())
+            self.assertTrue(str(receipt).startswith(str(runtime_root.resolve())))
+            self.assertEqual(Path(first_row["source_root"]), github_root.resolve())
+            self.assertEqual(Path(first_row["runtime_root"]), runtime_root.resolve())
 
             second_row = second["reusable_task_schedule"][0]
             self.assertEqual(second_row["outcome"], "ALREADY_RAN_THIS_SCHEDULE_SLOT")
             self.assertEqual(second_row["invocation_id"], first_row["invocation_id"])
+
+    def test_missing_resident_runtime_blocks_instead_of_using_source_as_runtime(self) -> None:
+        now = dt.datetime(2026, 9, 9, 9, 15, tzinfo=dt.timezone.utc)
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            github_root = self._github_root(tmp_root)
+            schedule = tmp_root / "schedule.json"
+            self._schedule(schedule)
+
+            with mock.patch.object(subject.base, "build_and_execute", return_value={"schema":"stegverse.healer.sovereign_scheduler_receipt/v0.1","state":"COMPLETE"}), \
+                 mock.patch.object(subject.base, "_repo_roots", return_value={"StegVerse-Labs/.github": github_root}), \
+                 mock.patch.object(subject.base, "_now", return_value=now), \
+                 mock.patch.dict("os.environ", {"RUN_SCOPE":"all","DISPATCH_MODE":"schedule","STEGVERSE_HEARTBEAT_ROOT":""}, clear=False):
+                result = subject.build_and_execute(tmp_root / "targets.json", schedule)
+
+            self.assertEqual(result["state"], "BLOCKED")
+            row = result["reusable_task_schedule"][0]
+            self.assertEqual(row["outcome"], "RESIDENT_RUNTIME_ROOT_NOT_MATERIALIZED")
+            self.assertIsNone(result["resident_runtime_root"])
 
     def test_config_binds_email_monitor_every_utc_hour(self) -> None:
         config = json.loads((ROOT / "data" / "reusable_task_schedule.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Goal
Repair the remaining execution-topology defect in `RT-NATIVE-EMAIL-ACTION-MONITOR-001` / `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` (`10100000100000`).

## Defect
The first hourly implementation passed the local `.github` source checkout as both `source_root` and `runtime_root`, and placed reusable-task slot receipts under the source checkout. That collapsed source and resident execution state.

## Repair
- resolve the resident heartbeat runtime explicitly from `STEGVERSE_HEARTBEAT_ROOT` when available;
- otherwise discover exactly one canonical local heartbeat-runtime location;
- require the materialized native-email standing request to prove the candidate is a resident runtime;
- pass local `.github` only as `source_root` and the resident heartbeat tree only as `runtime_root`;
- store `receipts/reusable-task/<hour-slot>.latest.json` in the resident runtime;
- preserve at-most-once execution per UTC hour;
- fail closed with `RESIDENT_RUNTIME_ROOT_NOT_MATERIALIZED` instead of treating source as runtime;
- update tests, README, and the native-email scheduler mirror handoff.

This keeps the existing single Healer scheduler and existing native email monitor. No second scheduler, polling loop, heartbeat, worker, or credential route is introduced.