### PR TITLE
Forward KnowledgeVault root into native email reusable slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Healer dispatch does not itself grant provider execution, deployment, custody, p
 - Data-driven reusable-task scheduling through `data/reusable_task_schedule.json` inside that same sovereign scheduler path; schedule slots are receipt-idempotent so an hourly reusable task runs at most once per UTC hour.
 - Scheduled reusable tasks keep source and resident runtime distinct: task source comes from the already-materialized local repository map, execution state and reusable-task receipts live under the resident runtime identified by `STEGVERSE_HEARTBEAT_ROOT`, and a missing resident runtime blocks rather than falling back to the source checkout.
 - `RT-NATIVE-EMAIL-ACTION-MONITOR-001` is scheduled hourly through the existing reusable-task trigger and canonical `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` path; no second mailbox monitor or scheduler is created.
+- The native-email reusable slot may receive the already-materialized KnowledgeVault path through `STEGVERSE_KV_ROOT` or `STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT`. These are non-secret local path bindings only; Healer does not mount a provider or acquire credentials. Missing KV materialization is handled by the downstream native-email consumer and blocks failure-email archival rather than bypassing KV persistence.
 - Unauthorized downstream schedule auditing.
 - Configured cross-repository workflow dispatch.
 - YAML correction and reusable repair workflows.

--- a/app/reusable_task_scheduler.py
+++ b/app/reusable_task_scheduler.py
@@ -19,6 +19,7 @@ import sovereign_scheduler as base
 SCHEDULE_FILE = Path(__file__).resolve().parents[1] / "data" / "reusable_task_schedule.json"
 RUNTIME_ROOT_ENV = "STEGVERSE_HEARTBEAT_ROOT"
 RUNTIME_REQUIRED_REL = Path("control/resident-execution-request.d/native-email-action-monitor-001.json")
+KV_PATH_ENV_NAMES = ("STEGVERSE_KV_ROOT", "STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT")
 
 
 def _load_schedule(path: Path) -> list[dict[str, Any]]:
@@ -77,6 +78,15 @@ def _resident_runtime_root() -> tuple[Path | None, str]:
     if len(unique) > 1:
         return None, "CANONICAL_RUNTIME_AMBIGUOUS"
     return None, "CANONICAL_RUNTIME_NOT_FOUND"
+
+
+def _kv_path_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    for name in KV_PATH_ENV_NAMES:
+        raw = str(os.getenv(name) or "").strip()
+        if raw:
+            values[name] = raw
+    return values
 
 
 def _execute_reusable_task(
@@ -142,15 +152,12 @@ def _execute_reusable_task(
         "--receipt",
         str(receipt_path),
     ]
-    result = base._run(
-        command,
-        root,
-        {
-            "STEGVERSE_REPO_ROOTS_JSON": roots_json,
-            RUNTIME_ROOT_ENV: str(runtime_root),
-        },
-        timeout=1500,
-    )
+    child_env = {
+        "STEGVERSE_REPO_ROOTS_JSON": roots_json,
+        RUNTIME_ROOT_ENV: str(runtime_root),
+        **_kv_path_env(),
+    }
+    result = base._run(command, root, child_env, timeout=1500)
     receipt = base._load_json(receipt_path) if receipt_path.is_file() else None
     ok = result["returncode"] == 0 and isinstance(receipt, dict)
     return {
@@ -162,6 +169,7 @@ def _execute_reusable_task(
         "receipt_state": receipt.get("state") if isinstance(receipt, dict) else None,
         "source_root": str(root),
         "runtime_root": str(runtime_root),
+        "kv_path_env_forwarded": sorted(name for name in KV_PATH_ENV_NAMES if name in child_env),
         "execution": result,
     }
 
@@ -189,6 +197,7 @@ def build_and_execute(config_path: Path, schedule_path: Path = SCHEDULE_FILE) ->
     receipt["reusable_task_schedule"] = scheduled
     receipt["resident_runtime_root"] = str(runtime_root) if runtime_root is not None else None
     receipt["resident_runtime_root_source"] = runtime_root_source
+    receipt["kv_path_env_available"] = sorted(_kv_path_env())
     if receipt.get("state") == "COMPLETE" and any(row.get("state") == "BLOCKED" for row in scheduled):
         receipt["state"] = "BLOCKED"
     return receipt

--- a/docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md
+++ b/docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md
@@ -8,8 +8,11 @@ Upstream COSV: `10100000100000`
 Upstream reusable identity: `RT-NATIVE-EMAIL-ACTION-MONITOR-001`
 Upstream scoped handoff: `StegVerse-Labs/.github:docs/NATIVE_EMAIL_REUSABLE_HOURLY_MIRROR_HANDOFF.md`
 Source merge: PR `#57` / merge `ef5d90a8c215056e055385a04534e16c49d9a3d5`
-Upstream merge: `StegVerse-Labs/.github#1252` / merge `700f959dca0160f0d71d92fc391c9f262f27feea`
-State: `SOURCE_INTEGRATION_MERGED / HOURLY_SLOT_CONFIGURATION_MERGED / SOURCE_RUNTIME_COLLAPSE_REPAIR_IN_PROGRESS / LIVE_SCHEDULE_RECEIPT_PENDING`
+Resident runtime-root merge: PR `#58` / merge `a0f6daeaf33198f26e358c7b124fc9f80aad8b6b`
+Upstream reusable source merge: `StegVerse-Labs/.github#1252` / merge `700f959dca0160f0d71d92fc391c9f262f27feea`
+Upstream standing recurrence merge: `StegVerse-Labs/.github#1259` / merge `569b6dde49cc9f568c0a24daf9fc723eee807b6f`
+Upstream WorkerCoordinator rearm merge: `StegVerse-Labs/.github#1273` / merge `438aeb9a4b187419ea3a91984ed0436c89b26819`
+State: `SOURCE_INTEGRATION_MERGED / HOURLY_SLOT_CONFIGURATION_MERGED / SOURCE_RUNTIME_SEPARATION_MERGED / STANDING_RECURRENCE_AND_REARM_MERGED / KV_PATH_FORWARDING_IN_VALIDATION / LIVE_SCHEDULE_AND_KV_RECEIPT_PENDING`
 
 ## Purpose
 
@@ -18,10 +21,11 @@ Schedule canonical reusable-task identities through the already-existing soverei
 ## Installed source
 
 - `data/reusable_task_schedule.json` — data-driven reusable-task schedule registry.
-- `app/reusable_task_scheduler.py` — extends the existing scheduler invocation with reusable-task slots.
+- `app/reusable_task_scheduler.py` — extends the existing scheduler invocation with reusable-task slots and forwards already-materialized non-secret KV path bindings when present.
 - `app/dispatch_orchestrators.py` — compatibility entrypoint enters the extended scheduler path.
 - `tests/test_reusable_task_scheduler.py` — proves hourly binding, resident-runtime separation, and same-slot idempotency.
-- `README.md` — documents reusable-task scheduling responsibility and resident-runtime semantics.
+- `tests/test_reusable_task_kv_env.py` — proves KV path forwarding into the reusable-task invocation.
+- `README.md` — documents reusable-task scheduling responsibility, resident-runtime semantics, and KV path forwarding boundary.
 
 ## Hourly contract
 
@@ -29,27 +33,52 @@ Schedule canonical reusable-task identities through the already-existing soverei
 
 The schedule invokes `.github/scripts/trigger_reusable_task.py` using the existing tracking Task ID `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` and COSV `10100000100000`. The local `.github` repository remains the source root. The resident heartbeat runtime supplied through `STEGVERSE_HEARTBEAT_ROOT` is the runtime root and receipt destination. The two roots must not collapse into the same source checkout. If the resident runtime is unavailable, the scheduled task fails closed with `RESIDENT_RUNTIME_ROOT_NOT_MATERIALIZED` instead of treating source as runtime.
 
-`STEGVERSE_REPO_ROOTS_JSON` remains the nonsecret local repository map used by the existing native-email consumer to resolve already-materialized TVC and StegOps provider-owner repositories.
+`STEGVERSE_REPO_ROOTS_JSON` remains the non-secret local repository map used by the existing native-email consumer to resolve already-materialized TVC and StegOps provider-owner repositories.
 
-## Defect repaired in current continuation
+## KV persistence path forwarding
 
-The first merged hourly implementation passed the local `.github` source checkout as both `source_root` and `runtime_root`, and wrote reusable-task slot receipts under the source checkout. That topology could make a source tree appear to be the resident execution surface and was incompatible with the separated resident runtime model.
+The upstream native-email task now requires normalized GitHub failure observations to be persisted to an already-materialized KnowledgeVault before the corresponding live Gmail messages may be archived. Healer does not mount KV, discover provider credentials, or perform the KV write itself. It forwards only already-present non-secret local path bindings:
 
-The current repair:
+```text
+STEGVERSE_KV_ROOT
+STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT
+```
 
-- resolves the runtime from `STEGVERSE_HEARTBEAT_ROOT`;
+The downstream `.github` consumer resolves one of those existing materialized roots and enforces the storage ordering. If neither resolves, the reusable invocation remains blocked/retryable and the live failure-email archive step is not permitted.
+
+The intended downstream sequence is:
+
+```text
+SEARCH_MESSAGES
+-> normalize failure incidents
+-> exact-byte KV write + readback
+-> ARCHIVE_IDS
+-> StegHealth reconciliation
+-> Canonical Work / InTr continuation when applicable
+```
+
+The KV path forwarding is metadata only. It adds no provider credential route, no second scheduler, and no alternate mailbox path.
+
+## Source/runtime separation repair already merged
+
+PR #58 repaired the initial implementation that passed the local `.github` source checkout as both `source_root` and `runtime_root`. The merged implementation now:
+
+- resolves the runtime from `STEGVERSE_HEARTBEAT_ROOT` or one canonical local runtime location;
 - passes the local `.github` checkout only as `source_root`;
 - passes the resident heartbeat runtime only as `runtime_root`;
 - stores `receipts/reusable-task/<slot>.latest.json` under the resident runtime;
 - blocks rather than falling back when the resident runtime is absent;
 - retains same-UTC-hour idempotency using the resident receipt.
 
-## Prior validation evidence
+## Validation evidence
 
-PR #57 exact head `99e63e6e01962232125f70becec5e21eac11ae30` passed Test Readiness run `34332190725`. The earlier run `34332041418` exposed only a test-fixture aliasing defect and was repaired without weakening scheduler production semantics.
-
-The coordinated `.github` PR #1252 exact head passed Heartbeat Worker Project run `34332023132`, organization-control run `34332023277`, and Deterministic Repository Suite run `34332023168` before merge.
+- PR #57 exact head `99e63e6e01962232125f70becec5e21eac11ae30`: Test Readiness `34332190725` SUCCESS.
+- PR #58 exact head `8fae4401381d7479373add148d21de6c514d2e7b`: Test Readiness `34356342498` SUCCESS.
+- Upstream #1252: Heartbeat `34332023132`, organization-control `34332023277`, deterministic suite `34332023168` SUCCESS.
+- Upstream #1259: Heartbeat `34352789541`, organization-control `34352789580`, deterministic suite `34352789603` SUCCESS.
+- Upstream #1273: organization-control `34358206486`, Heartbeat `34358206495`, deterministic suite `34358206492` SUCCESS.
+- KV forwarding validation is pending on `fix/native-email-kv-root-forwarding-20260909`.
 
 ## Evidence boundary
 
-Reusable identity, hourly schedule construction, standing Healer resident recurrence, source/runtime separation, same-slot idempotency, and resident receipt placement must all be merged and validated before live execution is claimed. Authentic live hourly operation still requires a retained resident reusable-task receipt plus the corresponding native-email/TV-TVC Gmail provider evidence for a mailbox-processing claim.
+Reusable identity, hourly schedule construction, standing Healer recurrence, WorkerCoordinator fresh-claim rearm, source/runtime separation, same-slot idempotency, resident receipt placement, and non-secret KV path forwarding must all be merged and validated before live execution is claimed. Authentic live operation additionally requires a retained resident reusable-task receipt, a native-email monitor receipt containing exact-byte KV write/readback evidence for any observed failure incidents, and the corresponding TV/TVC Gmail provider evidence. Source merge alone is not runtime proof.

--- a/tests/test_reusable_task_kv_env.py
+++ b/tests/test_reusable_task_kv_env.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from app import reusable_task_scheduler as scheduler
+
+
+class ReusableTaskKVEnvTests(unittest.TestCase):
+    def test_kv_path_projection_forwards_only_present_nonsecret_paths(self):
+        with patch.dict(os.environ, {
+            "STEGVERSE_KV_ROOT": "/local/KnowledgeVault",
+            "STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT": "/provider/KnowledgeVault",
+        }, clear=True):
+            self.assertEqual(scheduler._kv_path_env(), {
+                "STEGVERSE_KV_ROOT": "/local/KnowledgeVault",
+                "STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT": "/provider/KnowledgeVault",
+            })
+
+    def test_scheduled_reusable_task_receives_kv_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            source = base / ".github"
+            runtime = base / "heartbeat-runtime"
+            (source / "scripts").mkdir(parents=True)
+            (source / "scripts" / "trigger_reusable_task.py").write_text("# trigger\n", encoding="utf-8")
+            (runtime / scheduler.RUNTIME_REQUIRED_REL).parent.mkdir(parents=True)
+            (runtime / scheduler.RUNTIME_REQUIRED_REL).write_text("{}\n", encoding="utf-8")
+            kv_root = base / "KnowledgeVault"
+            kv_root.mkdir()
+            captured = {}
+
+            def fake_run(command, cwd, env, timeout):
+                captured.update(env)
+                receipt_path = Path(command[command.index("--receipt") + 1])
+                receipt_path.parent.mkdir(parents=True, exist_ok=True)
+                receipt_path.write_text(json.dumps({"state": "HANDOFF_READY"}) + "\n", encoding="utf-8")
+                return {"returncode": 0, "stdout": "", "stderr": ""}
+
+            task = {
+                "reusable_task_id": "RT-NATIVE-EMAIL-ACTION-MONITOR-001",
+                "tracking_task_id": "STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001",
+                "cosv_task_vector": "10100000100000",
+                "repository": "StegVerse-Labs/.github",
+                "parameters": {},
+            }
+            with patch.dict(os.environ, {"STEGVERSE_KV_ROOT": str(kv_root)}, clear=False), patch.object(scheduler.base, "_run", side_effect=fake_run):
+                result = scheduler._execute_reusable_task(
+                    task,
+                    {"StegVerse-Labs/.github": source},
+                    json.dumps({"StegVerse-Labs/.github": str(source)}),
+                    runtime,
+                    "EXPLICIT_NONSECRET_RUNTIME_ROOT",
+                    datetime(2026, 9, 9, 14, 0, tzinfo=timezone.utc),
+                )
+            self.assertEqual(result["state"], "COMPLETE")
+            self.assertEqual(captured["STEGVERSE_KV_ROOT"], str(kv_root))
+            self.assertIn("STEGVERSE_KV_ROOT", result["kv_path_env_forwarded"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reusable_task_kv_env.py
+++ b/tests/test_reusable_task_kv_env.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
-from app import reusable_task_scheduler as scheduler
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "app"
+if str(APP) not in sys.path:
+    sys.path.insert(0, str(APP))
+
+import reusable_task_scheduler as scheduler  # noqa: E402
 
 
 class ReusableTaskKVEnvTests(unittest.TestCase):


### PR DESCRIPTION
## Goal
Complete the existing `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` / COSV `10100000100000` path so the hourly native-email reusable task can receive the already-materialized KnowledgeVault root required by upstream fail-closed KV persistence.

## Changes
- forward only `STEGVERSE_KV_ROOT` and `STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT` when already present;
- pass them through the existing reusable-task scheduler child environment;
- do not mount a provider, acquire credentials, or create another scheduler/monitor path;
- add focused propagation tests;
- update README and native-email schedule mirror handoff.

The downstream `.github` consumer remains responsible for validating the KnowledgeVault root and blocks live failure-email archive if required KV persistence cannot complete.