### PR TITLE
Keep failed native-email hourly slots retryable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Healer dispatch does not itself grant provider execution, deployment, custody, p
 ## Current capabilities
 
 - Central hourly scheduler driven by `data/orchestrator_targets.json`.
-- Data-driven reusable-task scheduling through `data/reusable_task_schedule.json` inside that same sovereign scheduler path; schedule slots are receipt-idempotent so an hourly reusable task runs at most once per UTC hour.
+- Data-driven reusable-task scheduling through `data/reusable_task_schedule.json` inside that same sovereign scheduler path; a UTC-hour slot is idempotent only after its retained reusable-task receipt records `AUTOMATABLE_STEPS_EXHAUSTED`. Failed or boundary-only receipts remain retryable within the same hour instead of poisoning the slot.
 - Scheduled reusable tasks keep source and resident runtime distinct: task source comes from the already-materialized local repository map, execution state and reusable-task receipts live under the resident runtime identified by `STEGVERSE_HEARTBEAT_ROOT`, and a missing resident runtime blocks rather than falling back to the source checkout.
 - `RT-NATIVE-EMAIL-ACTION-MONITOR-001` is scheduled hourly through the existing reusable-task trigger and canonical `STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001` path; no second mailbox monitor or scheduler is created.
-- The native-email reusable slot may receive the already-materialized KnowledgeVault path through `STEGVERSE_KV_ROOT` or `STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT`. These are non-secret local path bindings only; Healer does not mount a provider or acquire credentials. Missing KV materialization is handled by the downstream native-email consumer and blocks failure-email archival rather than bypassing KV persistence.
+- The native-email reusable slot may receive the already-materialized KnowledgeVault path through `STEGVERSE_KV_ROOT` or `STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT`. These are non-secret local path bindings only; Healer does not mount a provider or acquire credentials. Missing KV materialization is handled by the downstream native-email consumer and blocks failure-email archival rather than bypassing KV persistence; that blocked attempt remains retryable in the current UTC-hour slot.
 - Unauthorized downstream schedule auditing.
 - Configured cross-repository workflow dispatch.
 - YAML correction and reusable repair workflows.

--- a/app/reusable_task_scheduler.py
+++ b/app/reusable_task_scheduler.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 """Extend the existing sovereign Healer scheduler with reusable-task schedules.
 
 This module is not a second scheduler. It is the single Healer scheduler entrypoint
-with an additional data-driven reusable-task schedule pass. Each schedule slot is
-idempotent by invocation id + retained resident-runtime receipt, so an hourly entry
-runs at most once per UTC hour even if the resident scheduler is visited repeatedly.
+with an additional data-driven reusable-task schedule pass. Each successful schedule
+slot is idempotent by invocation id + retained resident-runtime receipt. Failed or
+boundary-only attempts remain retryable within the same UTC hour.
 """
 
 import json
@@ -20,6 +20,7 @@ SCHEDULE_FILE = Path(__file__).resolve().parents[1] / "data" / "reusable_task_sc
 RUNTIME_ROOT_ENV = "STEGVERSE_HEARTBEAT_ROOT"
 RUNTIME_REQUIRED_REL = Path("control/resident-execution-request.d/native-email-action-monitor-001.json")
 KV_PATH_ENV_NAMES = ("STEGVERSE_KV_ROOT", "STEGVERSE_KV_PROVIDER_MATERIALIZED_ROOT")
+SUCCESSFUL_TRIGGER_STATE = "AUTOMATABLE_STEPS_EXHAUSTED"
 
 
 def _load_schedule(path: Path) -> list[dict[str, Any]]:
@@ -89,6 +90,10 @@ def _kv_path_env() -> dict[str, str]:
     return values
 
 
+def _receipt_satisfies_slot(receipt: dict[str, Any] | None) -> bool:
+    return bool(isinstance(receipt, dict) and receipt.get("state") == SUCCESSFUL_TRIGGER_STATE)
+
+
 def _execute_reusable_task(
     task: dict[str, Any],
     roots: dict[str, Path],
@@ -120,8 +125,8 @@ def _execute_reusable_task(
 
     invocation_id = _slot_id(reusable_task_id, now)
     receipt_path = runtime_root / "receipts" / "reusable-task" / f"{invocation_id}.latest.json"
-    if receipt_path.is_file():
-        prior = base._load_json(receipt_path)
+    prior = base._load_json(receipt_path) if receipt_path.is_file() else None
+    if _receipt_satisfies_slot(prior):
         return {
             **base_result,
             "state": "COMPLETE",
@@ -159,14 +164,16 @@ def _execute_reusable_task(
     }
     result = base._run(command, root, child_env, timeout=1500)
     receipt = base._load_json(receipt_path) if receipt_path.is_file() else None
-    ok = result["returncode"] == 0 and isinstance(receipt, dict)
+    ok = result["returncode"] == 0 and _receipt_satisfies_slot(receipt)
     return {
         **base_result,
         "state": "COMPLETE" if ok else "BLOCKED",
-        "outcome": "REUSABLE_TASK_SCHEDULE_SLOT_EXECUTED" if ok else "REUSABLE_TASK_SCHEDULE_SLOT_BLOCKED",
+        "outcome": "REUSABLE_TASK_SCHEDULE_SLOT_EXECUTED" if ok else "REUSABLE_TASK_SCHEDULE_SLOT_RETRYABLE",
         "invocation_id": invocation_id,
         "receipt_ref": str(receipt_path),
         "receipt_state": receipt.get("state") if isinstance(receipt, dict) else None,
+        "prior_receipt_state": prior.get("state") if isinstance(prior, dict) else None,
+        "same_slot_retry_permitted": not ok,
         "source_root": str(root),
         "runtime_root": str(runtime_root),
         "kv_path_env_forwarded": sorted(name for name in KV_PATH_ENV_NAMES if name in child_env),

--- a/tests/test_reusable_task_kv_env.py
+++ b/tests/test_reusable_task_kv_env.py
@@ -45,7 +45,10 @@ class ReusableTaskKVEnvTests(unittest.TestCase):
                 captured.update(env)
                 receipt_path = Path(command[command.index("--receipt") + 1])
                 receipt_path.parent.mkdir(parents=True, exist_ok=True)
-                receipt_path.write_text(json.dumps({"state": "HANDOFF_READY"}) + "\n", encoding="utf-8")
+                receipt_path.write_text(json.dumps({
+                    "schema": "stegverse.reusable-task-trigger-receipt/v1",
+                    "state": "AUTOMATABLE_STEPS_EXHAUSTED",
+                }) + "\n", encoding="utf-8")
                 return {"returncode": 0, "stdout": "", "stderr": ""}
 
             task = {

--- a/tests/test_reusable_task_retryable_slot.py
+++ b/tests/test_reusable_task_retryable_slot.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+import sys
+import tempfile
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "app"
+if str(APP) not in sys.path:
+    sys.path.insert(0, str(APP))
+
+import reusable_task_scheduler as subject  # noqa: E402
+
+
+def _runtime_root(base: Path) -> Path:
+    root = base / "heartbeat-runtime"
+    request = root / subject.RUNTIME_REQUIRED_REL
+    request.parent.mkdir(parents=True, exist_ok=True)
+    request.write_text("{}\n", encoding="utf-8")
+    return root
+
+
+def _schedule(path: Path) -> None:
+    path.write_text(json.dumps({
+        "schema": "stegverse.healer.reusable-task-schedule/v1",
+        "tasks": [{
+            "reusable_task_id": "RT-NATIVE-EMAIL-ACTION-MONITOR-001",
+            "tracking_task_id": "STEGVERSE-NATIVE-EMAIL-ACTION-MONITOR-001",
+            "cosv_task_vector": "10100000100000",
+            "repository": "StegVerse-Labs/.github",
+            "enabled": True,
+            "run_hours_utc": list(range(24)),
+            "parameters": {},
+        }],
+    }), encoding="utf-8")
+
+
+def test_boundary_receipt_does_not_poison_hourly_slot_and_is_retried():
+    now = dt.datetime(2026, 9, 10, 21, 15, tzinfo=dt.timezone.utc)
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        github_root = base / ".github"
+        trigger = github_root / "scripts" / "trigger_reusable_task.py"
+        trigger.parent.mkdir(parents=True)
+        trigger.write_text("print('placeholder')\n", encoding="utf-8")
+        runtime = _runtime_root(base)
+        schedule = base / "schedule.json"
+        _schedule(schedule)
+        invocation = "rt-native-email-action-monitor-001-20260910T21Z"
+        receipt = runtime / "receipts" / "reusable-task" / f"{invocation}.latest.json"
+        receipt.parent.mkdir(parents=True)
+        receipt.write_text(json.dumps({
+            "schema": "stegverse.reusable-task-trigger-receipt/v1",
+            "state": "BOUNDARY_RECORDED",
+            "boundary": {"kind": "DECLARED_RUNNER_STOPPED_BEFORE_COMPLETION"},
+        }) + "\n", encoding="utf-8")
+
+        calls = []
+        def fake_run(command, cwd, env, timeout):
+            calls.append(command)
+            receipt.write_text(json.dumps({
+                "schema": "stegverse.reusable-task-trigger-receipt/v1",
+                "state": "AUTOMATABLE_STEPS_EXHAUSTED",
+                "invocation_id": invocation,
+            }) + "\n", encoding="utf-8")
+            return {"returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+
+        with mock.patch.object(subject.base, "build_and_execute", return_value={"schema":"stegverse.healer.sovereign_scheduler_receipt/v0.1","state":"COMPLETE"}), \
+             mock.patch.object(subject.base, "_repo_roots", return_value={"StegVerse-Labs/.github": github_root}), \
+             mock.patch.object(subject.base, "_now", return_value=now), \
+             mock.patch.object(subject.base, "_run", side_effect=fake_run), \
+             mock.patch.dict("os.environ", {"RUN_SCOPE":"all","DISPATCH_MODE":"schedule","STEGVERSE_HEARTBEAT_ROOT":str(runtime)}, clear=False):
+            result = subject.build_and_execute(base / "targets.json", schedule)
+
+        assert len(calls) == 1
+        row = result["reusable_task_schedule"][0]
+        assert row["prior_receipt_state"] == "BOUNDARY_RECORDED"
+        assert row["receipt_state"] == "AUTOMATABLE_STEPS_EXHAUSTED"
+        assert row["outcome"] == "REUSABLE_TASK_SCHEDULE_SLOT_EXECUTED"
+        assert row["same_slot_retry_permitted"] is False
+
+
+def test_successful_receipt_is_the_only_slot_idempotency_terminal():
+    assert subject._receipt_satisfies_slot({"state": "AUTOMATABLE_STEPS_EXHAUSTED"}) is True
+    assert subject._receipt_satisfies_slot({"state": "BOUNDARY_RECORDED"}) is False
+    assert subject._receipt_satisfies_slot({"state": "FAILED"}) is False
+    assert subject._receipt_satisfies_slot(None) is False


### PR DESCRIPTION
## Goal
Prevent `RT-NATIVE-EMAIL-ACTION-MONITOR-001` from treating a failed or boundary-only reusable-task receipt as a successfully consumed UTC-hour slot.

## Defect
The scheduler previously treated any existing slot receipt as `ALREADY_RAN_THIS_SCHEDULE_SLOT`. `trigger_reusable_task.py` can retain `BOUNDARY_RECORDED` when the native-email runner cannot execute, so one failed attempt could poison the entire hour and suppress recovery.

## Repair
- only `AUTOMATABLE_STEPS_EXHAUSTED` satisfies a reusable UTC-hour slot;
- `BOUNDARY_RECORDED`, `FAILED`, missing, or other non-success receipts remain retryable in the same hour;
- post-run success now requires both process return code zero and the successful trigger receipt state;
- expose prior receipt state and same-slot retry status in the scheduler result;
- add regression coverage and update README semantics.

No new scheduler or polling loop is introduced.