### PR TITLE
Add immutable ECE finding intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This repository is the only managed StegVerse repository permitted to own schedu
 
 Healer dispatch does not itself grant provider execution, deployment, custody, publication, release, Site activation, admissibility, or receipt-minting authority.
 
+## Ecosystem Continuity Evaluator intake
+
+StegVerse-Healer consumes non-PASS findings from the canonical Ecosystem Continuity Evaluator as read-only repair-dispatch input. `app/ece_finding_intake.py` preserves the exact finding/evaluation identity, hashes the accepted snapshot, starts Healer state at `DETECTED`, and carries `authority_effect=NONE_INTAKE_ONLY`.
+
+ECE remains continuity-evaluation truth. Healer must not rewrite the underlying observation or claim recovery because work was acknowledged, queued, dispatched, retried, or completed. Recovery requires a later independent ECE evaluation that observes the predicate `PASS` with acceptable evidence and freshness. ECE scheduling, when introduced, must reuse the existing sovereign Healer scheduler and may not create a second scheduler.
+
 ## Current capabilities
 
 - Central hourly scheduler driven by `data/orchestrator_targets.json`.
@@ -29,6 +35,7 @@ Read these before modifying scheduling or dispatch behavior:
 - `docs/HEALER_MIRROR_HANDOFF.md`
 - `docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md`
 - `docs/HEALER_ACTIVATION_PLAN.md`
+- `docs/ECOSYSTEM_CONTINUITY_HEALER_INTAKE_MIRROR_HANDOFF.md`
 - `data/orchestrator_targets.json`
 - `data/reusable_task_schedule.json`
 - `data/summary/single_scheduler_migration.json`

--- a/app/ece_finding_intake.py
+++ b/app/ece_finding_intake.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Read-only intake for canonical Ecosystem Continuity Evaluator findings.
+
+This module prepares actionable findings for existing Healer dispatch semantics. It
+never changes the underlying ECE observation, marks recovery, or grants execution
+authority.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+EVALUATION_SCHEMA = "stegverse.ecosystem-continuity-evaluation.v1"
+INTAKE_SCHEMA = "stegverse.healer-ece-finding-intake.v1"
+ALLOWED_REMEDIATION = {
+    "NONE", "AUTO_REMEDIABLE", "DISPATCHABLE", "AUTHORITY_BOUNDARY", "HUMAN_BOUNDARY"
+}
+
+
+def _canonical_bytes(value) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def ingest(evaluation: dict) -> dict:
+    if evaluation.get("schema") != EVALUATION_SCHEMA:
+        raise ValueError("INVALID_ECE_SCHEMA")
+    if evaluation.get("authority_effect") != "NONE_DIAGNOSTIC_ONLY":
+        raise ValueError("ECE_AUTHORITY_EFFECT_REJECTED")
+    evaluation_id = evaluation.get("evaluation_id")
+    if not evaluation_id:
+        raise ValueError("MISSING_EVALUATION_ID")
+
+    items = []
+    for finding in evaluation.get("findings", []):
+        if finding.get("observation_state") == "PASS":
+            continue
+        remediation_class = finding.get("remediation_class")
+        if remediation_class not in ALLOWED_REMEDIATION:
+            raise ValueError("INVALID_REMEDIATION_CLASS")
+        snapshot = {
+            "finding_id": finding.get("finding_id"),
+            "evaluation_id": evaluation_id,
+            "component_id": finding.get("component_id"),
+            "predicate_id": finding.get("predicate_id"),
+            "observation_state": finding.get("observation_state"),
+            "severity": finding.get("severity"),
+            "continuity_critical": finding.get("continuity_critical"),
+            "evidence": list(finding.get("evidence", [])),
+            "evidence_age_seconds": finding.get("evidence_age_seconds"),
+            "authority_owner": finding.get("authority_owner"),
+            "remediation_class": remediation_class,
+        }
+        items.append({
+            "finding_snapshot": snapshot,
+            "finding_snapshot_sha256": hashlib.sha256(_canonical_bytes(snapshot)).hexdigest(),
+            "healer_state": "DETECTED",
+            "recovery_verified": False,
+            "dispatch_authority_effect": "NONE_INTAKE_ONLY",
+        })
+
+    return {
+        "schema": INTAKE_SCHEMA,
+        "source_evaluation_id": evaluation_id,
+        "source_continuity_state": evaluation.get("continuity_state"),
+        "items": items,
+        "authority_effect": "NONE_INTAKE_ONLY",
+        "recovery_rule": "LATER_INDEPENDENT_ECE_PASS_REQUIRED",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    evaluation = json.loads(Path(args.input).read_text())
+    result = ingest(evaluation)
+    Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ECOSYSTEM_CONTINUITY_HEALER_INTAKE_MIRROR_HANDOFF.md
+++ b/docs/ECOSYSTEM_CONTINUITY_HEALER_INTAKE_MIRROR_HANDOFF.md
@@ -1,0 +1,39 @@
+# Ecosystem Continuity Healer Intake Mirror Handoff
+
+Updated: 2026-09-11
+
+```text
+Parent Goal Task ID: ECOSYSTEM-CONTINUITY-EVALUATOR-001
+COSV: 71000000100111
+Repository: StegVerse-Labs/StegVerse-Healer
+Branch: feature/ece-finding-intake-001
+State: SOURCE_IMPLEMENTATION
+Authority effect: NONE_INTAKE_ONLY
+Scheduler owner: existing StegVerse-Healer sovereign scheduler
+```
+
+## Purpose
+
+Accept canonical ECE non-PASS findings as immutable repair-dispatch input without rewriting continuity truth, granting repair authority, or treating remediation activity as recovery proof.
+
+## Source
+
+```text
+app/ece_finding_intake.py
+tests/test_ece_finding_intake.py
+README.md
+```
+
+## Invariants
+
+- Input must be `stegverse.ecosystem-continuity-evaluation.v1` with `authority_effect=NONE_DIAGNOSTIC_ONLY`.
+- PASS findings are not queued for repair.
+- Accepted non-PASS findings receive a deterministic snapshot hash and initial Healer state `DETECTED`.
+- Intake authority is `NONE_INTAKE_ONLY`.
+- Healer acknowledgment, queueing, dispatch, retry, or repair receipts do not mutate the ECE observation and do not prove recovery.
+- `VERIFIED_RECOVERED` remains available only after a later independent ECE evaluation observes PASS with acceptable evidence/freshness.
+- No second scheduler is introduced.
+
+## Next
+
+Validate exact-head repository tests, then integrate this intake into the existing bounded sovereign scheduler path only after the canonical retained ECE evaluation transport/custody path is established. No live intake or dispatch is claimed by source merge alone.

--- a/tests/test_ece_finding_intake.py
+++ b/tests/test_ece_finding_intake.py
@@ -1,0 +1,61 @@
+import importlib.util
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("ece_intake", ROOT / "app" / "ece_finding_intake.py")
+MOD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MOD)
+
+
+def evaluation(state="FAIL"):
+    return {
+        "schema": "stegverse.ecosystem-continuity-evaluation.v1",
+        "evaluation_id": "ece_0123456789abcdef01234567",
+        "continuity_state": "INTERRUPTED",
+        "authority_effect": "NONE_DIAGNOSTIC_ONLY",
+        "findings": [{
+            "finding_id": "ecef_0123456789abcdef01234567",
+            "component_id": "intr",
+            "predicate_id": "resident_route",
+            "observation_state": state,
+            "severity": "CRITICAL",
+            "continuity_critical": True,
+            "evidence": ["mr://ece/evidence/1"],
+            "evidence_age_seconds": 2,
+            "authority_owner": "Interlock/InTr",
+            "remediation_class": "DISPATCHABLE",
+            "remediation_state": "DETECTED",
+        }],
+    }
+
+
+class IntakeTests(unittest.TestCase):
+    def test_non_pass_finding_becomes_detected_intake_only(self):
+        result = MOD.ingest(evaluation())
+        self.assertEqual(result["authority_effect"], "NONE_INTAKE_ONLY")
+        self.assertEqual(result["recovery_rule"], "LATER_INDEPENDENT_ECE_PASS_REQUIRED")
+        self.assertEqual(len(result["items"]), 1)
+        item = result["items"][0]
+        self.assertEqual(item["healer_state"], "DETECTED")
+        self.assertFalse(item["recovery_verified"])
+        self.assertEqual(item["dispatch_authority_effect"], "NONE_INTAKE_ONLY")
+
+    def test_pass_is_not_queued_as_repair(self):
+        result = MOD.ingest(evaluation("PASS"))
+        self.assertEqual(result["items"], [])
+
+    def test_authorizing_evaluation_is_rejected(self):
+        source = evaluation()
+        source["authority_effect"] = "EXECUTE"
+        with self.assertRaisesRegex(ValueError, "ECE_AUTHORITY_EFFECT_REJECTED"):
+            MOD.ingest(source)
+
+    def test_snapshot_is_deterministic(self):
+        left = MOD.ingest(evaluation())["items"][0]["finding_snapshot_sha256"]
+        right = MOD.ingest(evaluation())["items"][0]["finding_snapshot_sha256"]
+        self.assertEqual(left, right)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds read-only intake for canonical ECE non-PASS findings. Accepted snapshots are deterministically hashed, start at DETECTED, and carry NONE_INTAKE_ONLY authority. Healer activity cannot rewrite ECE observations or prove recovery; later independent ECE PASS remains required. Parent goal: ECOSYSTEM-CONTINUITY-EVALUATOR-001 / COSV 71000000100111. No live scheduling or dispatch is claimed by source alone.