### PR TITLE
Add bounded periodic ECE cycle implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Healer dispatch does not itself grant provider execution, deployment, custody, p
 
 StegVerse-Healer consumes non-PASS findings from the canonical Ecosystem Continuity Evaluator as read-only repair-dispatch input. `app/ece_finding_intake.py` preserves the exact finding/evaluation identity, hashes the accepted snapshot, starts Healer state at `DETECTED`, and carries `authority_effect=NONE_INTAKE_ONLY`.
 
-ECE remains continuity-evaluation truth. Healer must not rewrite the underlying observation or claim recovery because work was acknowledged, queued, dispatched, retried, or completed. Recovery requires a later independent ECE evaluation that observes the predicate `PASS` with acceptable evidence and freshness. ECE scheduling, when introduced, must reuse the existing sovereign Healer scheduler and may not create a second scheduler.
+ECE remains continuity-evaluation truth. Healer must not rewrite the underlying observation or claim recovery because work was acknowledged, queued, dispatched, retried, or completed. Recovery requires a later independent ECE evaluation that observes the predicate `PASS` with acceptable evidence and freshness.
+
+The bounded periodic cycle implementation is `app/ece_periodic_evaluation.py`, with CLI entrypoint `app/run_ece_periodic_evaluation.py`. It consumes only already-local canonical source roots plus the resident runtime root. When a resident observation bundle is absent, it supplies an empty observation set to the canonical evaluator so continuity degrades to explicit `NOT_OBSERVED` findings rather than inventing green state. Generated evaluation, exact-byte Master Records custody/reconstruction, Healer intake, Site-safe projection, and cycle receipts are written under the resident runtime root; source repositories remain read-only. Scheduling for this cycle must use the existing reusable-task scheduler extension and must not create another scheduler.
 
 ## Current capabilities
 
@@ -36,6 +38,7 @@ Read these before modifying scheduling or dispatch behavior:
 - `docs/NATIVE_EMAIL_REUSABLE_SCHEDULE_MIRROR_HANDOFF.md`
 - `docs/HEALER_ACTIVATION_PLAN.md`
 - `docs/ECOSYSTEM_CONTINUITY_HEALER_INTAKE_MIRROR_HANDOFF.md`
+- `docs/ECOSYSTEM_CONTINUITY_PERIODIC_CYCLE_MIRROR_HANDOFF.md`
 - `data/orchestrator_targets.json`
 - `data/reusable_task_schedule.json`
 - `data/summary/single_scheduler_migration.json`

--- a/app/ece_periodic_evaluation.py
+++ b/app/ece_periodic_evaluation.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Run one bounded periodic ECE cycle from already-local canonical source.
+
+The cycle is non-authorizing. It reads an optional resident observation bundle,
+executes the canonical ECE evaluator, retains exact bytes through the canonical
+Master Records custody/reconstruction source, prepares Healer finding intake,
+and creates a Site-safe projection. All generated state is written under the
+resident runtime root; source repositories remain read-only.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _run(command: list[str], cwd: Path, timeout: int = 120) -> dict[str, Any]:
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "LC_ALL": os.environ.get("LC_ALL", "C.UTF-8"),
+    }
+    proc = subprocess.run(command, cwd=cwd, env=env, text=True, capture_output=True, check=False, timeout=timeout)
+    return {
+        "command": command,
+        "returncode": proc.returncode,
+        "stdout_tail": proc.stdout[-4000:],
+        "stderr_tail": proc.stderr[-4000:],
+    }
+
+
+def _require_file(path: Path, label: str) -> None:
+    if not path.is_file():
+        raise RuntimeError(f"ECE_SOURCE_MISSING:{label}:{path}")
+
+
+def execute_periodic_ece(roots: dict[str, Path], resident_root: Path, evaluated_at: str | None = None) -> dict[str, Any]:
+    github_root = roots.get("StegVerse-Labs/.github")
+    site_root = roots.get("StegVerse-Labs/Site")
+    mr_root = roots.get("master-records/orchestration")
+    healer_root = roots.get("StegVerse-Labs/StegVerse-Healer")
+    missing = [name for name, value in {
+        "StegVerse-Labs/.github": github_root,
+        "StegVerse-Labs/Site": site_root,
+        "master-records/orchestration": mr_root,
+        "StegVerse-Labs/StegVerse-Healer": healer_root,
+    }.items() if value is None]
+    if missing:
+        return {
+            "state": "BLOCKED",
+            "outcome": "ECE_REQUIRED_LOCAL_SOURCE_MISSING",
+            "missing": sorted(missing),
+            "authority_effect": "NONE",
+        }
+
+    assert github_root is not None and site_root is not None and mr_root is not None and healer_root is not None
+    evaluator = github_root / "scripts" / "evaluate_ecosystem_continuity.py"
+    registry = github_root / "data" / "ecosystem-continuity-registry.json"
+    mr_ingest = mr_root / "scripts" / "ingest_ecosystem_continuity_evaluation.py"
+    mr_reconstruct = mr_root / "scripts" / "reconstruct_ecosystem_continuity_evaluation.py"
+    healer_intake = healer_root / "app" / "ece_finding_intake.py"
+    site_projection = site_root / "scripts" / "project_ecosystem_continuity.py"
+    for path, label in [
+        (evaluator, "evaluator"), (registry, "registry"), (mr_ingest, "master_records_ingest"),
+        (mr_reconstruct, "master_records_reconstruct"), (healer_intake, "healer_intake"),
+        (site_projection, "site_projection"),
+    ]:
+        _require_file(path, label)
+
+    resident_root = resident_root.expanduser().resolve()
+    output_root = resident_root / "receipts" / "ecosystem-continuity"
+    custody_root = resident_root / "master-records" / "ecosystem-continuity"
+    output_root.mkdir(parents=True, exist_ok=True)
+    custody_root.mkdir(parents=True, exist_ok=True)
+
+    explicit_observations = os.getenv("STEGVERSE_ECE_OBSERVATIONS", "").strip()
+    resident_observations = Path(explicit_observations).expanduser().resolve() if explicit_observations else output_root / "observations.latest.json"
+    observation_bundle_present = resident_observations.is_file()
+
+    with tempfile.TemporaryDirectory(prefix="stegverse-ece-") as td:
+        temp_root = Path(td)
+        if observation_bundle_present:
+            observations = resident_observations
+        else:
+            observations = temp_root / "observations.empty.json"
+            observations.write_text(json.dumps({"observations": []}, sort_keys=True) + "\n", encoding="utf-8")
+
+        temp_evaluation = temp_root / "evaluation.json"
+        evaluated_at = evaluated_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        steps: list[dict[str, Any]] = []
+
+        evaluation_run = _run([
+            sys.executable, str(evaluator), "--registry", str(registry), "--observations", str(observations),
+            "--output", str(temp_evaluation), "--evaluated-at", evaluated_at,
+        ], github_root)
+        steps.append(evaluation_run)
+        if evaluation_run["returncode"] != 0 or not temp_evaluation.is_file():
+            return {"state":"BLOCKED","outcome":"ECE_EVALUATION_FAILED","execution":steps,"authority_effect":"NONE"}
+
+        evaluation = json.loads(temp_evaluation.read_text(encoding="utf-8"))
+        if evaluation.get("authority_effect") != "NONE_DIAGNOSTIC_ONLY":
+            return {"state":"BLOCKED","outcome":"ECE_EVALUATION_AUTHORITY_DRIFT","execution":steps,"authority_effect":"NONE"}
+        evaluation_id = str(evaluation.get("evaluation_id", ""))
+        if not evaluation_id.startswith("ece_"):
+            return {"state":"BLOCKED","outcome":"ECE_EVALUATION_ID_INVALID","execution":steps,"authority_effect":"NONE"}
+
+        exact_eval = output_root / f"{evaluation_id}.evaluation.json"
+        latest_eval = output_root / "evaluation.latest.json"
+        raw = temp_evaluation.read_bytes()
+        if exact_eval.exists() and exact_eval.read_bytes() != raw:
+            return {"state":"BLOCKED","outcome":"ECE_RESIDENT_IDENTITY_CONFLICT","evaluation_id":evaluation_id,"authority_effect":"NONE"}
+        exact_eval.write_bytes(raw)
+        latest_eval.write_bytes(raw)
+
+        custody_run = _run([
+            sys.executable, str(mr_ingest), "--evaluation", str(exact_eval), "--custody-root", str(custody_root),
+        ], mr_root)
+        steps.append(custody_run)
+        if custody_run["returncode"] != 0:
+            return {"state":"BLOCKED","outcome":"ECE_MASTER_RECORDS_CUSTODY_FAILED","evaluation_id":evaluation_id,"execution":steps,"authority_effect":"NONE"}
+        try:
+            custody_result = json.loads(custody_run["stdout_tail"].strip().splitlines()[-1])
+        except Exception:
+            return {"state":"BLOCKED","outcome":"ECE_MASTER_RECORDS_CUSTODY_RECEIPT_INVALID","evaluation_id":evaluation_id,"execution":steps,"authority_effect":"NONE"}
+
+        custody_ref = Path(str(custody_result.get("custody_ref", "")))
+        reconstructed = temp_root / "reconstructed.json"
+        reconstruction_run = _run([
+            sys.executable, str(mr_reconstruct), "--record", str(custody_ref), "--custody-root", str(custody_root), "--output", str(reconstructed),
+        ], mr_root)
+        steps.append(reconstruction_run)
+        if reconstruction_run["returncode"] != 0 or not reconstructed.is_file() or reconstructed.read_bytes() != raw:
+            return {"state":"BLOCKED","outcome":"ECE_MASTER_RECORDS_RECONSTRUCTION_FAILED","evaluation_id":evaluation_id,"execution":steps,"authority_effect":"NONE"}
+
+        intake_path = output_root / "healer-intake.latest.json"
+        intake_run = _run([sys.executable, str(healer_intake), "--input", str(exact_eval), "--output", str(intake_path)], healer_root)
+        steps.append(intake_run)
+        if intake_run["returncode"] != 0 or not intake_path.is_file():
+            return {"state":"BLOCKED","outcome":"ECE_HEALER_INTAKE_FAILED","evaluation_id":evaluation_id,"execution":steps,"authority_effect":"NONE"}
+
+        projection_path = output_root / "site-projection.latest.json"
+        projection_run = _run([sys.executable, str(site_projection), "--input", str(exact_eval), "--output", str(projection_path)], site_root)
+        steps.append(projection_run)
+        if projection_run["returncode"] != 0 or not projection_path.is_file():
+            return {"state":"BLOCKED","outcome":"ECE_SITE_PROJECTION_FAILED","evaluation_id":evaluation_id,"execution":steps,"authority_effect":"NONE"}
+
+    receipt = {
+        "schema": "stegverse.healer-ecosystem-continuity-cycle/v1",
+        "state": "COMPLETE",
+        "evaluation_id": evaluation_id,
+        "evaluated_at": evaluated_at,
+        "continuity_state": evaluation.get("continuity_state"),
+        "observation_bundle_present": observation_bundle_present,
+        "observation_source": str(resident_observations) if observation_bundle_present else None,
+        "evaluation_ref": str(exact_eval),
+        "evaluation_sha256": _sha256(exact_eval),
+        "custody_ref": str(custody_ref),
+        "custody_sha256": _sha256(custody_ref),
+        "healer_intake_ref": str(intake_path),
+        "healer_intake_sha256": _sha256(intake_path),
+        "site_projection_ref": str(projection_path),
+        "site_projection_sha256": _sha256(projection_path),
+        "source_repository_writeback": False,
+        "github_token_required": False,
+        "second_scheduler_created": False,
+        "recovery_verified": False,
+        "recovery_rule": "LATER_INDEPENDENT_ECE_PASS_REQUIRED",
+        "authority_effect": "NONE",
+        "execution": steps,
+    }
+    receipt_path = output_root / "cycle.latest.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return receipt

--- a/app/run_ece_periodic_evaluation.py
+++ b/app/run_ece_periodic_evaluation.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from app.ece_periodic_evaluation import execute_periodic_ece
+
+
+def main() -> int:
+    raw_roots = os.getenv("STEGVERSE_REPO_ROOTS_JSON", "").strip()
+    raw_runtime = os.getenv("STEGVERSE_HEARTBEAT_ROOT", "").strip()
+    if not raw_roots or not raw_runtime:
+        print(json.dumps({"state":"BLOCKED","outcome":"ECE_RUNTIME_BINDING_MISSING","authority_effect":"NONE"}, sort_keys=True))
+        return 3
+    parsed = json.loads(raw_roots)
+    if not isinstance(parsed, dict):
+        raise SystemExit("STEGVERSE_REPO_ROOTS_JSON must be an object")
+    roots = {str(repo): Path(str(path)).expanduser().resolve() for repo, path in parsed.items()}
+    result = execute_periodic_ece(roots, Path(raw_runtime))
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result.get("state") == "COMPLETE" else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/reusable_task_schedule.json
+++ b/data/reusable_task_schedule.json
@@ -16,6 +16,23 @@
         "observation_window": "since previous scheduled invocation"
       },
       "status": "hourly-existing-reusable-task-trigger-bounded-retry-no-second-monitor-no-second-scheduler"
+    },
+    {
+      "reusable_task_id": "RT-ECOSYSTEM-CONTINUITY-EVALUATION-001",
+      "tracking_task_id": "ECOSYSTEM-CONTINUITY-EVALUATOR-001",
+      "cosv_task_vector": "71000000100111",
+      "repository": "StegVerse-Labs/.github",
+      "enabled": true,
+      "aliases": ["ece", "ecosystem-continuity", "continuity-evaluation"],
+      "run_hours_utc": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "retry_interval_minutes": 15,
+      "max_attempts_per_slot": 4,
+      "parameters": {
+        "observation_source": "resident receipts/ecosystem-continuity/observations.latest.json when present",
+        "resident_output_scope": "receipts/ecosystem-continuity + master-records/ecosystem-continuity",
+        "cadence": "hourly UTC through existing reusable-task scheduler"
+      },
+      "status": "hourly-existing-reusable-task-trigger-ece-no-second-scheduler-no-synthetic-pass"
     }
   ]
 }

--- a/docs/ECOSYSTEM_CONTINUITY_PERIODIC_CYCLE_MIRROR_HANDOFF.md
+++ b/docs/ECOSYSTEM_CONTINUITY_PERIODIC_CYCLE_MIRROR_HANDOFF.md
@@ -7,23 +7,32 @@ Parent Goal Task ID: ECOSYSTEM-CONTINUITY-EVALUATOR-001
 COSV: 71000000100111
 Repository: StegVerse-Labs/StegVerse-Healer
 Branch: feature/ece-periodic-sovereign-schedule-001
-State: CYCLE_SOURCE_IMPLEMENTED / REUSABLE_SCHEDULE_BINDING_PENDING
+State: CYCLE_SOURCE + HOURLY REUSABLE SCHEDULE BINDING IMPLEMENTED / VALIDATION PENDING
 Authority effect: NONE
 Scheduler owner: existing StegVerse-Healer sovereign reusable-task scheduler extension
+Cross-repo reusable identity: StegVerse-Labs/.github RT-ECOSYSTEM-CONTINUITY-EVALUATION-001
 ```
 
 ## Purpose
 
-Provide one bounded periodic continuity cycle implementation that consumes already-local ECE, Site, Healer, and Master Records source, evaluates resident observations, retains exact evaluation bytes, reconstructs them, creates immutable Healer intake, and produces the Site-safe projection without source-repository writeback or a second scheduler.
+Provide one bounded periodic continuity cycle that consumes already-local ECE, Site, Healer, and Master Records source, evaluates resident observations, retains exact evaluation bytes, reconstructs them, creates immutable Healer intake, and produces the Site-safe projection without source-repository writeback or a second scheduler.
 
 ## Source
 
 ```text
 app/ece_periodic_evaluation.py
 app/run_ece_periodic_evaluation.py
+data/reusable_task_schedule.json
 tests/test_ece_periodic_evaluation.py
+tests/test_ece_reusable_schedule.py
 README.md
 ```
+
+## Schedule binding
+
+The existing Healer reusable-task scheduler now contains one enabled row for `RT-ECOSYSTEM-CONTINUITY-EVALUATION-001`, tracked by canonical task `ECOSYSTEM-CONTINUITY-EVALUATOR-001` / COSV `71000000100111`. The initial cadence is hourly UTC, using the existing deterministic UTC-hour slot ID, 15-minute retry interval, and maximum four attempts per slot. This adds no scheduler, timer, heartbeat, polling service, or WorkerCoordinator.
+
+The cross-repository `.github` reusable-task definition and runner bridge are being implemented under the same parent ECE goal. The schedule is executable only when that canonical identity/runner and all required already-local source roots are materialized.
 
 ## Runtime contract
 
@@ -49,7 +58,7 @@ STEGVERSE_ECE_OBSERVATIONS
 or <resident>/receipts/ecosystem-continuity/observations.latest.json
 ```
 
-If no observation bundle is present, the cycle runs with an empty observation set. The canonical evaluator therefore emits `NOT_OBSERVED` findings and an appropriately degraded continuity classification instead of synthesizing PASS evidence.
+If no observation bundle is present, the cycle uses an empty observation set. The canonical evaluator therefore emits `NOT_OBSERVED` findings and an appropriately degraded continuity classification instead of synthesizing PASS evidence.
 
 ## Resident outputs
 
@@ -71,8 +80,12 @@ receipts/ecosystem-continuity/cycle.latest.json
 - Healer intake remains `NONE_INTAKE_ONLY` and cannot verify recovery.
 - Site projection remains read-only/fail-closed.
 - `recovery_verified` is always false for this cycle; a later independent ECE PASS is required.
-- The implementation creates no scheduler. Periodic invocation must be registered through the existing reusable-task schedule path.
+- Scheduling reuses the existing reusable-task scheduler extension and creates no second scheduler.
+
+## Current proof boundary
+
+Source implementation and schedule configuration are not runtime activation evidence. No authentic ECE schedule slot, resident evaluation, Master Records runtime custody, Healer runtime intake, Site runtime projection, or recovery loop is claimed until retained resident evidence exists.
 
 ## Next
 
-Validate this cycle source, then register one reusable ECE identity/runner in the canonical `.github` reusable-task registry and bind it hourly in `data/reusable_task_schedule.json`. Source merge alone does not prove a resident cycle executed or that any authentic ecosystem observation has been retained.
+Pass exact-head Healer validation; merge only together with a validated canonical `.github` reusable identity/runner contract. Then observe the existing resident scheduler consuming one ECE slot before claiming periodic execution.

--- a/docs/ECOSYSTEM_CONTINUITY_PERIODIC_CYCLE_MIRROR_HANDOFF.md
+++ b/docs/ECOSYSTEM_CONTINUITY_PERIODIC_CYCLE_MIRROR_HANDOFF.md
@@ -1,0 +1,78 @@
+# Ecosystem Continuity Periodic Cycle Mirror Handoff
+
+Updated: 2026-09-11
+
+```text
+Parent Goal Task ID: ECOSYSTEM-CONTINUITY-EVALUATOR-001
+COSV: 71000000100111
+Repository: StegVerse-Labs/StegVerse-Healer
+Branch: feature/ece-periodic-sovereign-schedule-001
+State: CYCLE_SOURCE_IMPLEMENTED / REUSABLE_SCHEDULE_BINDING_PENDING
+Authority effect: NONE
+Scheduler owner: existing StegVerse-Healer sovereign reusable-task scheduler extension
+```
+
+## Purpose
+
+Provide one bounded periodic continuity cycle implementation that consumes already-local ECE, Site, Healer, and Master Records source, evaluates resident observations, retains exact evaluation bytes, reconstructs them, creates immutable Healer intake, and produces the Site-safe projection without source-repository writeback or a second scheduler.
+
+## Source
+
+```text
+app/ece_periodic_evaluation.py
+app/run_ece_periodic_evaluation.py
+tests/test_ece_periodic_evaluation.py
+README.md
+```
+
+## Runtime contract
+
+Required already-local source roots:
+
+```text
+StegVerse-Labs/.github
+StegVerse-Labs/Site
+StegVerse-Labs/StegVerse-Healer
+master-records/orchestration
+```
+
+Required resident root:
+
+```text
+STEGVERSE_HEARTBEAT_ROOT
+```
+
+Optional authentic observation input:
+
+```text
+STEGVERSE_ECE_OBSERVATIONS
+or <resident>/receipts/ecosystem-continuity/observations.latest.json
+```
+
+If no observation bundle is present, the cycle runs with an empty observation set. The canonical evaluator therefore emits `NOT_OBSERVED` findings and an appropriately degraded continuity classification instead of synthesizing PASS evidence.
+
+## Resident outputs
+
+```text
+receipts/ecosystem-continuity/<evaluation_id>.evaluation.json
+receipts/ecosystem-continuity/evaluation.latest.json
+master-records/ecosystem-continuity/<evaluation_id>.evaluation.json
+master-records/ecosystem-continuity/<evaluation_id>.custody.json
+receipts/ecosystem-continuity/healer-intake.latest.json
+receipts/ecosystem-continuity/site-projection.latest.json
+receipts/ecosystem-continuity/cycle.latest.json
+```
+
+## Invariants
+
+- Source repositories remain read-only during a cycle.
+- Missing required local source blocks rather than fetching from GitHub/network.
+- Master Records custody/reconstruction must round-trip exact evaluation bytes before downstream intake/projection completes.
+- Healer intake remains `NONE_INTAKE_ONLY` and cannot verify recovery.
+- Site projection remains read-only/fail-closed.
+- `recovery_verified` is always false for this cycle; a later independent ECE PASS is required.
+- The implementation creates no scheduler. Periodic invocation must be registered through the existing reusable-task schedule path.
+
+## Next
+
+Validate this cycle source, then register one reusable ECE identity/runner in the canonical `.github` reusable-task registry and bind it hourly in `data/reusable_task_schedule.json`. Source merge alone does not prove a resident cycle executed or that any authentic ecosystem observation has been retained.

--- a/tests/test_ece_periodic_evaluation.py
+++ b/tests/test_ece_periodic_evaluation.py
@@ -1,0 +1,30 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("ece_cycle", ROOT / "app" / "ece_periodic_evaluation.py")
+MOD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MOD)
+
+
+class PeriodicEvaluationTests(unittest.TestCase):
+    def test_missing_required_local_source_blocks_without_authority(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = MOD.execute_periodic_ece({}, pathlib.Path(td))
+        self.assertEqual(result["state"], "BLOCKED")
+        self.assertEqual(result["outcome"], "ECE_REQUIRED_LOCAL_SOURCE_MISSING")
+        self.assertEqual(result["authority_effect"], "NONE")
+        self.assertIn("master-records/orchestration", result["missing"])
+        self.assertIn("StegVerse-Labs/.github", result["missing"])
+
+    def test_missing_source_does_not_create_runtime_outputs(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = pathlib.Path(td)
+            MOD.execute_periodic_ece({}, runtime)
+            self.assertFalse((runtime / "receipts" / "ecosystem-continuity").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ece_reusable_schedule.py
+++ b/tests/test_ece_reusable_schedule.py
@@ -1,0 +1,24 @@
+import json
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class EcosystemContinuityScheduleTests(unittest.TestCase):
+    def test_ece_schedule_binds_parent_task_every_utc_hour(self):
+        config = json.loads((ROOT / "data" / "reusable_task_schedule.json").read_text(encoding="utf-8"))
+        rows = [row for row in config["tasks"] if row.get("reusable_task_id") == "RT-ECOSYSTEM-CONTINUITY-EVALUATION-001"]
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["tracking_task_id"], "ECOSYSTEM-CONTINUITY-EVALUATOR-001")
+        self.assertEqual(row["cosv_task_vector"], "71000000100111")
+        self.assertEqual(row["repository"], "StegVerse-Labs/.github")
+        self.assertEqual(row["run_hours_utc"], list(range(24)))
+        self.assertEqual(row["retry_interval_minutes"], 15)
+        self.assertEqual(row["max_attempts_per_slot"], 4)
+        self.assertIn("no-second-scheduler", row["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the non-scheduling execution chain for one periodic Ecosystem Continuity Evaluation cycle. It uses already-local .github/Site/Healer/Master Records source, resident observations when present, exact-byte Master Records custody/reconstruction, immutable Healer intake, and Site-safe projection; all generated state remains under the resident runtime root. No second scheduler and no runtime execution are claimed. Parent goal ECOSYSTEM-CONTINUITY-EVALUATOR-001 / COSV 71000000100111.