### PR TITLE
Route periodic ECE through SDK ecosystem diagnostics

### DIFF
--- a/app/ece_periodic_evaluation.py
+++ b/app/ece_periodic_evaluation.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Run one bounded periodic ECE cycle from already-local canonical source.
+"""Run one bounded periodic ECE cycle through the installed SDK diagnostic processor.
 
-The cycle is non-authorizing. It reads an optional resident observation bundle,
-executes the canonical ECE evaluator, retains exact bytes through the canonical
-Master Records custody/reconstruction source, prepares Healer finding intake,
-and creates a Site-safe projection. All generated state is written under the
-resident runtime root; source repositories remain read-only.
+The cycle is non-authorizing. It converts the canonical ECE registry plus optional
+resident observations into a manifested ``ecosystem_diagnostic`` SDK request,
+retains the exact SDK diagnostic-result bytes, translates only those results into
+ECE observation input, executes the canonical ECE evaluator, retains exact ECE
+bytes through Master Records custody/reconstruction, prepares Healer finding
+intake, and creates a Site-safe projection. Source repositories remain read-only.
 """
 from __future__ import annotations
 
@@ -22,6 +23,11 @@ from typing import Any
 
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_sha256(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
 
 
 def _run(command: list[str], cwd: Path, timeout: int = 120) -> dict[str, Any]:
@@ -45,16 +51,93 @@ def _require_file(path: Path, label: str) -> None:
         raise RuntimeError(f"ECE_SOURCE_MISSING:{label}:{path}")
 
 
+def _diagnostic_request(registry: dict[str, Any], observations: dict[str, Any], evaluated_at: str) -> dict[str, Any]:
+    observation_map = {
+        (row.get("component_id"), row.get("predicate_id")): row
+        for row in observations.get("observations", [])
+        if isinstance(row, dict)
+    }
+    tests: list[dict[str, Any]] = []
+    for component in registry.get("components", []):
+        component_id = component["component_id"]
+        owner = component["authority_owner"]
+        for predicate in component.get("predicates", []):
+            predicate_id = predicate["predicate_id"]
+            source = observation_map.get((component_id, predicate_id))
+            observation = None
+            if source is not None:
+                observation = {
+                    "state": source.get("state", "UNKNOWN"),
+                    "observed_at": source.get("observed_at"),
+                    "evidence_refs": list(source.get("evidence", [])),
+                    "evidence_age_seconds": source.get("evidence_age_seconds"),
+                    "detail": source.get("detail"),
+                }
+            tests.append({
+                "test_id": f"ece:{component_id}:{predicate_id}",
+                "component_id": component_id,
+                "predicate_id": predicate_id,
+                "authority_owner": owner,
+                "observation": observation,
+            })
+    return {
+        "schema": "stegverse.ecosystem-diagnostic-request.v1",
+        "diagnostic_request_id": "ece-sdk-" + hashlib.sha256(
+            f"{evaluated_at}:{_canonical_sha256(registry)}".encode("utf-8")
+        ).hexdigest()[:24],
+        "scope": "ecosystem",
+        "mutation_permitted": False,
+        "expected_evidence_fields": ["evidence_refs", "observed_at"],
+        "tests": tests,
+    }
+
+
+def _ece_observations_from_diagnostic(result: dict[str, Any], diagnostic_sha256: str) -> dict[str, Any]:
+    if result.get("schema") != "stegverse.ecosystem-diagnostic-result.v1":
+        raise ValueError("SDK_DIAGNOSTIC_RESULT_SCHEMA_INVALID")
+    if result.get("processing_capability") != "ecosystem_diagnostic":
+        raise ValueError("SDK_DIAGNOSTIC_RESULT_CAPABILITY_DRIFT")
+    if result.get("route_id") != "stegverse.route.ecosystem-diagnostic.v1":
+        raise ValueError("SDK_DIAGNOSTIC_RESULT_ROUTE_DRIFT")
+    if result.get("authority_effect") != "NONE_DIAGNOSTIC_ONLY":
+        raise ValueError("SDK_DIAGNOSTIC_RESULT_AUTHORITY_DRIFT")
+    if result.get("mutation_performed") is not False:
+        raise ValueError("SDK_DIAGNOSTIC_RESULT_MUTATION_DRIFT")
+    if result.get("continuity_state_present") is not False or "continuity_state" in result:
+        raise ValueError("SDK_DIAGNOSTIC_RESULT_MUST_NOT_SUPPLY_CONTINUITY")
+
+    envelope_ref = f"sdk-diagnostic-result-sha256:{diagnostic_sha256}"
+    translated = []
+    for row in result.get("results", []):
+        if not isinstance(row, dict):
+            raise ValueError("SDK_DIAGNOSTIC_RESULT_ROW_INVALID")
+        evidence = list(row.get("evidence_refs") or [])
+        if envelope_ref not in evidence:
+            evidence.append(envelope_ref)
+        translated.append({
+            "component_id": row.get("component_id"),
+            "predicate_id": row.get("predicate_id"),
+            "state": row.get("observation_state"),
+            "evidence": evidence,
+            "evidence_age_seconds": row.get("evidence_age_seconds"),
+            "detail": row.get("detail") or "",
+            "sdk_diagnostic_test_id": row.get("test_id"),
+        })
+    return {"observations": translated}
+
+
 def execute_periodic_ece(roots: dict[str, Path], resident_root: Path, evaluated_at: str | None = None) -> dict[str, Any]:
     github_root = roots.get("StegVerse-Labs/.github")
     site_root = roots.get("StegVerse-Labs/Site")
     mr_root = roots.get("master-records/orchestration")
     healer_root = roots.get("StegVerse-Labs/StegVerse-Healer")
+    sdk_root = roots.get("StegVerse-org/StegVerse-SDK")
     missing = [name for name, value in {
         "StegVerse-Labs/.github": github_root,
         "StegVerse-Labs/Site": site_root,
         "master-records/orchestration": mr_root,
         "StegVerse-Labs/StegVerse-Healer": healer_root,
+        "StegVerse-org/StegVerse-SDK": sdk_root,
     }.items() if value is None]
     if missing:
         return {
@@ -64,17 +147,21 @@ def execute_periodic_ece(roots: dict[str, Path], resident_root: Path, evaluated_
             "authority_effect": "NONE",
         }
 
-    assert github_root is not None and site_root is not None and mr_root is not None and healer_root is not None
+    assert github_root is not None and site_root is not None and mr_root is not None and healer_root is not None and sdk_root is not None
     evaluator = github_root / "scripts" / "evaluate_ecosystem_continuity.py"
-    registry = github_root / "data" / "ecosystem-continuity-registry.json"
+    registry_path = github_root / "data" / "ecosystem-continuity-registry.json"
+    sdk_builder = sdk_root / "stegverse" / "manifest_builder.py"
+    sdk_runtime = sdk_root / "stegverse" / "ecosystem_diagnostic_runtime.py"
+    sdk_cli = sdk_root / "stegverse" / "ecosystem_diagnostic_cli.py"
     mr_ingest = mr_root / "scripts" / "ingest_ecosystem_continuity_evaluation.py"
     mr_reconstruct = mr_root / "scripts" / "reconstruct_ecosystem_continuity_evaluation.py"
     healer_intake = healer_root / "app" / "ece_finding_intake.py"
     site_projection = site_root / "scripts" / "project_ecosystem_continuity.py"
     for path, label in [
-        (evaluator, "evaluator"), (registry, "registry"), (mr_ingest, "master_records_ingest"),
-        (mr_reconstruct, "master_records_reconstruct"), (healer_intake, "healer_intake"),
-        (site_projection, "site_projection"),
+        (evaluator, "evaluator"), (registry_path, "registry"),
+        (sdk_builder, "sdk_manifest_builder"), (sdk_runtime, "sdk_diagnostic_runtime"), (sdk_cli, "sdk_diagnostic_cli"),
+        (mr_ingest, "master_records_ingest"), (mr_reconstruct, "master_records_reconstruct"),
+        (healer_intake, "healer_intake"), (site_projection, "site_projection"),
     ]:
         _require_file(path, label)
 
@@ -87,21 +174,75 @@ def execute_periodic_ece(roots: dict[str, Path], resident_root: Path, evaluated_
     explicit_observations = os.getenv("STEGVERSE_ECE_OBSERVATIONS", "").strip()
     resident_observations = Path(explicit_observations).expanduser().resolve() if explicit_observations else output_root / "observations.latest.json"
     observation_bundle_present = resident_observations.is_file()
+    evaluated_at = evaluated_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
 
-    with tempfile.TemporaryDirectory(prefix="stegverse-ece-") as td:
+    with tempfile.TemporaryDirectory(prefix="stegverse-ece-sdk-") as td:
         temp_root = Path(td)
         if observation_bundle_present:
-            observations = resident_observations
+            source_observations = json.loads(resident_observations.read_text(encoding="utf-8"))
         else:
-            observations = temp_root / "observations.empty.json"
-            observations.write_text(json.dumps({"observations": []}, sort_keys=True) + "\n", encoding="utf-8")
+            source_observations = {"observations": []}
 
-        temp_evaluation = temp_root / "evaluation.json"
-        evaluated_at = evaluated_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        diagnostic_request = _diagnostic_request(registry, source_observations, evaluated_at)
+        request_path = temp_root / "diagnostic-request.json"
+        request_path.write_text(json.dumps(diagnostic_request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        source_payload = {
+            "schema": "stegverse.ece-diagnostic-cycle-source.v1",
+            "evaluated_at": evaluated_at,
+            "registry_sha256": _canonical_sha256(registry),
+            "observation_bundle_present": observation_bundle_present,
+            "observation_bundle_sha256": _canonical_sha256(source_observations),
+        }
+        payload_path = temp_root / "diagnostic-source.json"
+        payload_path.write_text(json.dumps(source_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        manifest_path = temp_root / "diagnostic-manifest.json"
+        diagnostic_result_temp = temp_root / "diagnostic-result.json"
         steps: list[dict[str, Any]] = []
 
+        build_run = _run([
+            sys.executable, "-m", "stegverse.manifest_builder", "build",
+            "--input", str(payload_path), "--processor-request", str(request_path),
+            "--process", "ecosystem_diagnostic", "--source-framework", "StegVerse-Healer",
+            "--source-output-id", diagnostic_request["diagnostic_request_id"],
+            "--data-class", "stegverse.ece-diagnostic-cycle-source.v1",
+            "--return-depth", "result+evidence", "--created-at", evaluated_at,
+            "--output", str(manifest_path),
+        ], sdk_root)
+        steps.append(build_run)
+        if build_run["returncode"] != 0 or not manifest_path.is_file():
+            return {"state":"BLOCKED","outcome":"ECE_SDK_DIAGNOSTIC_MANIFEST_BUILD_FAILED","execution":steps,"authority_effect":"NONE"}
+
+        sdk_run = _run([
+            sys.executable, "-m", "stegverse.ecosystem_diagnostic_cli",
+            "--manifest", str(manifest_path), "--output", str(diagnostic_result_temp),
+        ], sdk_root)
+        steps.append(sdk_run)
+        if sdk_run["returncode"] != 0 or not diagnostic_result_temp.is_file():
+            return {"state":"BLOCKED","outcome":"ECE_SDK_DIAGNOSTIC_EXECUTION_FAILED","execution":steps,"authority_effect":"NONE"}
+
+        diagnostic_raw = diagnostic_result_temp.read_bytes()
+        diagnostic_sha = hashlib.sha256(diagnostic_raw).hexdigest()
+        diagnostic_id = "sdkdiag_" + diagnostic_sha[:24]
+        exact_diagnostic = output_root / f"{diagnostic_id}.result.json"
+        latest_diagnostic = output_root / "sdk-diagnostic-result.latest.json"
+        if exact_diagnostic.exists() and exact_diagnostic.read_bytes() != diagnostic_raw:
+            return {"state":"BLOCKED","outcome":"ECE_SDK_DIAGNOSTIC_IDENTITY_CONFLICT","diagnostic_result_id":diagnostic_id,"authority_effect":"NONE"}
+        exact_diagnostic.write_bytes(diagnostic_raw)
+        latest_diagnostic.write_bytes(diagnostic_raw)
+        diagnostic_result = json.loads(diagnostic_raw)
+
+        try:
+            ece_observation_bundle = _ece_observations_from_diagnostic(diagnostic_result, diagnostic_sha)
+        except ValueError as exc:
+            return {"state":"BLOCKED","outcome":str(exc),"diagnostic_result_id":diagnostic_id,"authority_effect":"NONE"}
+        translated_observations = temp_root / "ece-observations-from-sdk.json"
+        translated_observations.write_text(json.dumps(ece_observation_bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        temp_evaluation = temp_root / "evaluation.json"
         evaluation_run = _run([
-            sys.executable, str(evaluator), "--registry", str(registry), "--observations", str(observations),
+            sys.executable, str(evaluator), "--registry", str(registry_path), "--observations", str(translated_observations),
             "--output", str(temp_evaluation), "--evaluated-at", evaluated_at,
         ], github_root)
         steps.append(evaluation_run)
@@ -163,6 +304,11 @@ def execute_periodic_ece(roots: dict[str, Path], resident_root: Path, evaluated_
         "continuity_state": evaluation.get("continuity_state"),
         "observation_bundle_present": observation_bundle_present,
         "observation_source": str(resident_observations) if observation_bundle_present else None,
+        "sdk_diagnostic_request_id": diagnostic_request["diagnostic_request_id"],
+        "sdk_diagnostic_result_id": diagnostic_id,
+        "sdk_diagnostic_result_ref": str(exact_diagnostic),
+        "sdk_diagnostic_result_sha256": diagnostic_sha,
+        "sdk_diagnostic_result_bound_into_ece": True,
         "evaluation_ref": str(exact_eval),
         "evaluation_sha256": _sha256(exact_eval),
         "custody_ref": str(custody_ref),
@@ -174,6 +320,8 @@ def execute_periodic_ece(roots: dict[str, Path], resident_root: Path, evaluated_
         "source_repository_writeback": False,
         "github_token_required": False,
         "second_scheduler_created": False,
+        "sdk_diagnostic_mutation_performed": False,
+        "sdk_diagnostic_continuity_authority": False,
         "recovery_verified": False,
         "recovery_rule": "LATER_INDEPENDENT_ECE_PASS_REQUIRED",
         "authority_effect": "NONE",

--- a/docs/ECOSYSTEM_CONTINUITY_PERIODIC_CYCLE_MIRROR_HANDOFF.md
+++ b/docs/ECOSYSTEM_CONTINUITY_PERIODIC_CYCLE_MIRROR_HANDOFF.md
@@ -1,13 +1,15 @@
 # Ecosystem Continuity Periodic Cycle Mirror Handoff
 
-Updated: 2026-09-11
+Updated: 2026-09-12
 
 ```text
 Parent Goal Task ID: ECOSYSTEM-CONTINUITY-EVALUATOR-001
-COSV: 71000000100111
+Child Goal Task ID: SDK-ECOSYSTEM-DIAGNOSTIC-PROCESSOR-001
+Parent COSV: 71000000100111
+Child COSV: 71000000101000
 Repository: StegVerse-Labs/StegVerse-Healer
-Branch: feature/ece-periodic-sovereign-schedule-001
-State: CYCLE_SOURCE + HOURLY REUSABLE SCHEDULE BINDING IMPLEMENTED / VALIDATION PENDING
+Branch: feature/ece-sdk-diagnostic-bridge-001
+State: SDK DIAGNOSTIC BRIDGE SOURCE IMPLEMENTED / VALIDATION PENDING
 Authority effect: NONE
 Scheduler owner: existing StegVerse-Healer sovereign reusable-task scheduler extension
 Cross-repo reusable identity: StegVerse-Labs/.github RT-ECOSYSTEM-CONTINUITY-EVALUATION-001
@@ -15,54 +17,84 @@ Cross-repo reusable identity: StegVerse-Labs/.github RT-ECOSYSTEM-CONTINUITY-EVA
 
 ## Purpose
 
-Provide one bounded periodic continuity cycle that consumes already-local ECE, Site, Healer, and Master Records source, evaluates resident observations, retains exact evaluation bytes, reconstructs them, creates immutable Healer intake, and produces the Site-safe projection without source-repository writeback or a second scheduler.
+Provide one bounded periodic continuity cycle that routes registered ecosystem diagnostic tests through the installed StegVerse SDK `ecosystem_diagnostic` processor before ECE interprets continuity. The SDK returns diagnostic observations only; ECE remains the sole continuity interpreter; Master Records retains/reconstructs the resulting ECE evaluation; Healer consumes findings; Site receives a safe projection.
 
-## Source
+## Runtime chain
 
 ```text
-app/ece_periodic_evaluation.py
-app/run_ece_periodic_evaluation.py
-data/reusable_task_schedule.json
-tests/test_ece_periodic_evaluation.py
-tests/test_ece_reusable_schedule.py
-README.md
+existing Healer hourly reusable slot
+-> canonical ECE registry + optional resident observation bundle
+-> SDK diagnostic request
+-> stegverse.ingress-manifest.v1
+-> processing.capability = ecosystem_diagnostic
+-> stegverse.route.ecosystem-diagnostic.v1
+-> exact SDK diagnostic result bytes + SHA-256 retained in resident runtime
+-> SDK result translated to ECE observation input
+-> canonical ECE continuity evaluation
+-> exact Master Records custody/reconstruction
+-> Healer intake
+-> Site-safe projection
 ```
 
-## Schedule binding
-
-The existing Healer reusable-task scheduler now contains one enabled row for `RT-ECOSYSTEM-CONTINUITY-EVALUATION-001`, tracked by canonical task `ECOSYSTEM-CONTINUITY-EVALUATOR-001` / COSV `71000000100111`. The initial cadence is hourly UTC, using the existing deterministic UTC-hour slot ID, 15-minute retry interval, and maximum four attempts per slot. This adds no scheduler, timer, heartbeat, polling service, or WorkerCoordinator.
-
-The cross-repository `.github` reusable-task definition and runner bridge are being implemented under the same parent ECE goal. The schedule is executable only when that canonical identity/runner and all required already-local source roots are materialized.
-
-## Runtime contract
-
-Required already-local source roots:
+## Required already-local source roots
 
 ```text
 StegVerse-Labs/.github
 StegVerse-Labs/Site
 StegVerse-Labs/StegVerse-Healer
+StegVerse-org/StegVerse-SDK
 master-records/orchestration
 ```
 
-Required resident root:
+No source is fetched from GitHub/network during resident execution. Missing required local source blocks fail-closed.
+
+## Diagnostic request construction
+
+The cycle expands every registered ECE component/predicate into one SDK diagnostic test with stable identity `ece:<component_id>:<predicate_id>`. Existing resident observations are carried as source observation packets; missing observations remain `null` and therefore become SDK `NOT_OBSERVED` results. The request pre-registers expected evidence fields:
 
 ```text
-STEGVERSE_HEARTBEAT_ROOT
+evidence_refs
+observed_at
 ```
 
-Optional authentic observation input:
+The SDK v1 request always declares `mutation_permitted=false`.
+
+## Exact SDK-result binding
+
+The exact SDK diagnostic result bytes are retained under the resident continuity receipt directory:
 
 ```text
-STEGVERSE_ECE_OBSERVATIONS
-or <resident>/receipts/ecosystem-continuity/observations.latest.json
+receipts/ecosystem-continuity/sdkdiag_<sha-prefix>.result.json
+receipts/ecosystem-continuity/sdk-diagnostic-result.latest.json
 ```
 
-If no observation bundle is present, the cycle uses an empty observation set. The canonical evaluator therefore emits `NOT_OBSERVED` findings and an appropriately degraded continuity classification instead of synthesizing PASS evidence.
+The cycle computes the exact SHA-256 of those bytes. Every translated ECE observation preserves its underlying SDK evidence references and also carries a result-envelope provenance reference:
+
+```text
+sdk-diagnostic-result-sha256:<exact-result-sha256>
+```
+
+This binds the ECE finding/evaluation chain back to the exact SDK diagnostic artifact without treating the envelope hash as proof that the underlying predicate passed.
+
+## Fail-closed SDK boundary
+
+Before ECE executes, the cycle rejects an SDK result when any of the following occurs:
+
+- result schema is not `stegverse.ecosystem-diagnostic-result.v1`;
+- processing capability is not `ecosystem_diagnostic`;
+- route is not `stegverse.route.ecosystem-diagnostic.v1`;
+- `authority_effect` is not `NONE_DIAGNOSTIC_ONLY`;
+- `mutation_performed` is not false;
+- `continuity_state_present` is not false;
+- any `continuity_state` value is supplied by the SDK result.
+
+The SDK diagnoses; ECE interprets continuity. That boundary is structural, not advisory.
 
 ## Resident outputs
 
 ```text
+receipts/ecosystem-continuity/sdkdiag_<sha-prefix>.result.json
+receipts/ecosystem-continuity/sdk-diagnostic-result.latest.json
 receipts/ecosystem-continuity/<evaluation_id>.evaluation.json
 receipts/ecosystem-continuity/evaluation.latest.json
 master-records/ecosystem-continuity/<evaluation_id>.evaluation.json
@@ -72,20 +104,26 @@ receipts/ecosystem-continuity/site-projection.latest.json
 receipts/ecosystem-continuity/cycle.latest.json
 ```
 
+`cycle.latest.json` records the SDK diagnostic request ID, deterministic result ID, exact result ref/SHA-256, and `sdk_diagnostic_result_bound_into_ece=true` when the chain completes.
+
 ## Invariants
 
 - Source repositories remain read-only during a cycle.
 - Missing required local source blocks rather than fetching from GitHub/network.
-- Master Records custody/reconstruction must round-trip exact evaluation bytes before downstream intake/projection completes.
-- Healer intake remains `NONE_INTAKE_ONLY` and cannot verify recovery.
+- SDK diagnostic mutation is forbidden in v1.
+- SDK diagnostic results cannot supply continuity state.
+- Missing observation stays `NOT_OBSERVED`; unsupported claimed evidence remains subject to SDK `PROBE_REQUIRED` semantics.
+- Exact SDK diagnostic result identity is retained into ECE evidence provenance.
+- Master Records custody/reconstruction must round-trip exact ECE evaluation bytes before downstream intake/projection completes.
+- Healer intake remains non-authorizing and cannot verify recovery.
 - Site projection remains read-only/fail-closed.
 - `recovery_verified` is always false for this cycle; a later independent ECE PASS is required.
 - Scheduling reuses the existing reusable-task scheduler extension and creates no second scheduler.
 
 ## Current proof boundary
 
-Source implementation and schedule configuration are not runtime activation evidence. No authentic ECE schedule slot, resident evaluation, Master Records runtime custody, Healer runtime intake, Site runtime projection, or recovery loop is claimed until retained resident evidence exists.
+The SDK processor source is merged+validated, and this bridge source is implemented on the current Healer branch. No authentic resident SDK diagnostic request/result, resident ECE evaluation, Master Records runtime custody, Healer runtime intake, Site runtime projection, or recovery loop is claimed until retained resident evidence exists.
 
 ## Next
 
-Pass exact-head Healer validation; merge only together with a validated canonical `.github` reusable identity/runner contract. Then observe the existing resident scheduler consuming one ECE slot before claiming periodic execution.
+Pass exact-head Healer validation and merge this bridge only if green. Then reconcile the child SDK task and parent ECE handoffs. After merge, observe one authentic resident `RT-ECOSYSTEM-CONTINUITY-EVALUATION-001` slot producing the SDK diagnostic result + ECE + custody/intake/projection chain before claiming the SDK diagnostic continuity lane operational.

--- a/tests/test_ece_periodic_evaluation.py
+++ b/tests/test_ece_periodic_evaluation.py
@@ -18,12 +18,84 @@ class PeriodicEvaluationTests(unittest.TestCase):
         self.assertEqual(result["authority_effect"], "NONE")
         self.assertIn("master-records/orchestration", result["missing"])
         self.assertIn("StegVerse-Labs/.github", result["missing"])
+        self.assertIn("StegVerse-org/StegVerse-SDK", result["missing"])
 
     def test_missing_source_does_not_create_runtime_outputs(self):
         with tempfile.TemporaryDirectory() as td:
             runtime = pathlib.Path(td)
             MOD.execute_periodic_ece({}, runtime)
             self.assertFalse((runtime / "receipts" / "ecosystem-continuity").exists())
+
+    def test_diagnostic_request_covers_registry_and_preserves_missing_observation(self):
+        registry = {
+            "components": [{
+                "component_id": "sdk",
+                "authority_owner": "StegVerse-org/StegVerse-SDK",
+                "predicates": [{"predicate_id": "route_installed"}],
+            }]
+        }
+        request = MOD._diagnostic_request(registry, {"observations": []}, "2026-09-12T05:00:00Z")
+        self.assertEqual(request["schema"], "stegverse.ecosystem-diagnostic-request.v1")
+        self.assertEqual(request["scope"], "ecosystem")
+        self.assertFalse(request["mutation_permitted"])
+        self.assertEqual(request["expected_evidence_fields"], ["evidence_refs", "observed_at"])
+        self.assertEqual(request["tests"][0]["component_id"], "sdk")
+        self.assertIsNone(request["tests"][0]["observation"])
+
+    def test_sdk_result_translation_binds_exact_result_hash(self):
+        result = {
+            "schema": "stegverse.ecosystem-diagnostic-result.v1",
+            "processing_capability": "ecosystem_diagnostic",
+            "route_id": "stegverse.route.ecosystem-diagnostic.v1",
+            "scope": "ecosystem",
+            "results": [{
+                "test_id": "ece:sdk:route_installed",
+                "component_id": "sdk",
+                "predicate_id": "route_installed",
+                "observation_state": "PASS",
+                "evidence_refs": ["receipt:abc"],
+                "evidence_age_seconds": 4,
+                "authority_owner": "StegVerse-org/StegVerse-SDK",
+                "detail": "observed",
+                "mutation_performed": False,
+            }],
+            "mutation_performed": False,
+            "authority_effect": "NONE_DIAGNOSTIC_ONLY",
+            "continuity_state_present": False,
+        }
+        translated = MOD._ece_observations_from_diagnostic(result, "a" * 64)
+        row = translated["observations"][0]
+        self.assertEqual(row["state"], "PASS")
+        self.assertIn("receipt:abc", row["evidence"])
+        self.assertIn("sdk-diagnostic-result-sha256:" + "a" * 64, row["evidence"])
+        self.assertEqual(row["sdk_diagnostic_test_id"], "ece:sdk:route_installed")
+
+    def test_sdk_result_cannot_supply_continuity_state(self):
+        result = {
+            "schema": "stegverse.ecosystem-diagnostic-result.v1",
+            "processing_capability": "ecosystem_diagnostic",
+            "route_id": "stegverse.route.ecosystem-diagnostic.v1",
+            "results": [],
+            "mutation_performed": False,
+            "authority_effect": "NONE_DIAGNOSTIC_ONLY",
+            "continuity_state_present": False,
+            "continuity_state": "CONTINUOUS",
+        }
+        with self.assertRaisesRegex(ValueError, "MUST_NOT_SUPPLY_CONTINUITY"):
+            MOD._ece_observations_from_diagnostic(result, "b" * 64)
+
+    def test_sdk_result_authority_drift_fails_closed(self):
+        result = {
+            "schema": "stegverse.ecosystem-diagnostic-result.v1",
+            "processing_capability": "ecosystem_diagnostic",
+            "route_id": "stegverse.route.ecosystem-diagnostic.v1",
+            "results": [],
+            "mutation_performed": False,
+            "authority_effect": "EXECUTE",
+            "continuity_state_present": False,
+        }
+        with self.assertRaisesRegex(ValueError, "AUTHORITY_DRIFT"):
+            MOD._ece_observations_from_diagnostic(result, "c" * 64)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the remaining source bridge for SDK-ECOSYSTEM-DIAGNOSTIC-PROCESSOR-001 / COSV 71000000101000 under parent ECOSYSTEM-CONTINUITY-EVALUATOR-001. The existing Healer periodic ECE cycle now requires already-local StegVerse-SDK source, builds a manifested ecosystem_diagnostic request from the canonical ECE registry plus optional resident observations, executes the installed SDK processor, retains the exact diagnostic-result bytes and SHA-256, translates only those diagnostic results into ECE observations, and then continues through the existing ECE -> Master Records -> Healer intake -> Site-safe projection chain. SDK mutation, authority drift, route/capability drift, or any SDK-supplied continuity state fail closed before ECE execution. Source/CI does not prove authentic resident diagnostic execution.