### PR TITLE
Bind ECE cycle to Site current projection materializer

### DIFF
--- a/app/run_ece_periodic_evaluation.py
+++ b/app/run_ece_periodic_evaluation.py
@@ -3,9 +3,109 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 from app.ece_periodic_evaluation import execute_periodic_ece
+
+
+def _persist_cycle(receipt_path: Path, result: dict) -> None:
+    receipt_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def bind_site_materialization(result: dict, roots: dict[str, Path], runtime_root: Path) -> dict:
+    """Optionally copy the exact Site-safe projection into an already-bound served Site root.
+
+    Absence of a served-root binding is not an ECE failure: diagnostic/evaluation/custody
+    may complete while public materialization remains unobserved. Once a served root is
+    explicitly bound, however, materialization fails closed on any receipt/hash/authority
+    error rather than silently presenting stale state.
+    """
+    if result.get("state") != "COMPLETE":
+        return result
+
+    output_root = runtime_root.expanduser().resolve() / "receipts" / "ecosystem-continuity"
+    cycle_receipt = output_root / "cycle.latest.json"
+    if not cycle_receipt.is_file():
+        return {"state":"BLOCKED","outcome":"ECE_CYCLE_RECEIPT_MISSING_BEFORE_SITE_MATERIALIZATION","authority_effect":"NONE"}
+
+    served_raw = os.getenv("STEGVERSE_SITE_SERVED_ROOT", "").strip()
+    if not served_raw:
+        result["site_materialization_state"] = "NOT_BOUND"
+        result["site_live_publication_observed"] = False
+        _persist_cycle(cycle_receipt, result)
+        return result
+
+    site_root = roots.get("StegVerse-Labs/Site")
+    if site_root is None:
+        return {"state":"BLOCKED","outcome":"ECE_SITE_LOCAL_SOURCE_MISSING_FOR_MATERIALIZER","authority_effect":"NONE"}
+    materializer = site_root / "scripts" / "materialize_ecosystem_continuity_current.py"
+    if not materializer.is_file():
+        return {"state":"BLOCKED","outcome":"ECE_SITE_MATERIALIZER_SOURCE_MISSING","authority_effect":"NONE"}
+
+    projection_ref = result.get("site_projection_ref")
+    projection_sha = result.get("site_projection_sha256")
+    if not isinstance(projection_ref, str) or not projection_ref or not isinstance(projection_sha, str) or len(projection_sha) != 64:
+        return {"state":"BLOCKED","outcome":"ECE_SITE_PROJECTION_BINDING_INVALID","authority_effect":"NONE"}
+
+    materialization_receipt = output_root / "site-materialization.latest.json"
+    command = [
+        sys.executable, str(materializer),
+        "--cycle-receipt", str(cycle_receipt),
+        "--projection", projection_ref,
+        "--served-site-root", str(Path(served_raw).expanduser().resolve()),
+        "--source-site-root", str(site_root),
+        "--receipt-output", str(materialization_receipt),
+    ]
+    proc = subprocess.run(command, cwd=site_root, text=True, capture_output=True, check=False, timeout=120)
+    result.setdefault("execution", []).append({
+        "command": command,
+        "returncode": proc.returncode,
+        "stdout_tail": proc.stdout[-4000:],
+        "stderr_tail": proc.stderr[-4000:],
+    })
+    if proc.returncode != 0 or not materialization_receipt.is_file():
+        result.update({
+            "state": "BLOCKED",
+            "outcome": "ECE_SITE_MATERIALIZATION_FAILED",
+            "site_materialization_state": "BLOCKED",
+            "site_live_publication_observed": False,
+        })
+        _persist_cycle(cycle_receipt, result)
+        return result
+
+    try:
+        receipt = json.loads(materialization_receipt.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        result.update({"state":"BLOCKED","outcome":"ECE_SITE_MATERIALIZATION_RECEIPT_INVALID","site_materialization_state":"BLOCKED"})
+        _persist_cycle(cycle_receipt, result)
+        return result
+
+    valid = (
+        receipt.get("schema") == "stegverse.site-ecosystem-continuity-materialization-receipt.v1"
+        and receipt.get("state") == "COMPLETE"
+        and receipt.get("authority_effect") == "NONE_COPY_ONLY"
+        and receipt.get("projection_sha256") == projection_sha
+        and receipt.get("exact_bytes_preserved") is True
+        and receipt.get("continuity_recalculated") is False
+        and receipt.get("live_publication_observed") is False
+        and receipt.get("recovery_verified") is False
+    )
+    if not valid:
+        result.update({"state":"BLOCKED","outcome":"ECE_SITE_MATERIALIZATION_RECEIPT_DRIFT","site_materialization_state":"BLOCKED"})
+        _persist_cycle(cycle_receipt, result)
+        return result
+
+    result.update({
+        "site_materialization_state": "MATERIALIZED_PENDING_PUBLIC_OBSERVATION",
+        "site_materialization_receipt_ref": str(materialization_receipt),
+        "site_current_projection_ref": receipt.get("target_ref"),
+        "site_current_projection_sha256": receipt.get("projection_sha256"),
+        "site_live_publication_observed": False,
+    })
+    _persist_cycle(cycle_receipt, result)
+    return result
 
 
 def main() -> int:
@@ -18,7 +118,9 @@ def main() -> int:
     if not isinstance(parsed, dict):
         raise SystemExit("STEGVERSE_REPO_ROOTS_JSON must be an object")
     roots = {str(repo): Path(str(path)).expanduser().resolve() for repo, path in parsed.items()}
-    result = execute_periodic_ece(roots, Path(raw_runtime))
+    runtime_root = Path(raw_runtime).expanduser().resolve()
+    result = execute_periodic_ece(roots, runtime_root)
+    result = bind_site_materialization(result, roots, runtime_root)
     print(json.dumps(result, sort_keys=True))
     return 0 if result.get("state") == "COMPLETE" else 3
 

--- a/docs/ECOSYSTEM_CONTINUITY_SITE_MATERIALIZER_BINDING_MIRROR_HANDOFF.md
+++ b/docs/ECOSYSTEM_CONTINUITY_SITE_MATERIALIZER_BINDING_MIRROR_HANDOFF.md
@@ -1,0 +1,34 @@
+# Ecosystem Continuity Site Materializer Binding Mirror Handoff
+
+Updated: 2026-09-12
+
+```text
+Goal Task ID: SITE-ECE-CURRENT-PROJECTION-MATERIALIZER-001
+Parent Task ID: ECOSYSTEM-CONTINUITY-EVALUATOR-001
+COSV: 71000000102000
+Repository: StegVerse-Labs/StegVerse-Healer
+State: SOURCE IMPLEMENTED / VALIDATION PENDING
+Authority effect: NONE
+```
+
+## Purpose
+
+Bind the existing completed Healer ECE cycle to the Site copy-only current-projection materializer without moving continuity interpretation or publication authority into Healer.
+
+## Binding
+
+`app/run_ece_periodic_evaluation.py` now invokes Site `scripts/materialize_ecosystem_continuity_current.py` only after the canonical SDK diagnostic -> ECE -> Master Records -> Healer intake -> Site-safe projection cycle has completed and written `cycle.latest.json`.
+
+The served runtime root is optional and must be supplied as `STEGVERSE_SITE_SERVED_ROOT`.
+
+- If absent, the cycle stays `COMPLETE` and records `site_materialization_state=NOT_BOUND` plus `site_live_publication_observed=false`.
+- If explicitly supplied, missing Site source, invalid projection binding, materializer failure, or receipt drift blocks rather than serving stale data.
+- A valid materialization records `MATERIALIZED_PENDING_PUBLIC_OBSERVATION`; it never sets live publication or recovery true.
+
+## Authority boundary
+
+The runner does not calculate continuity, rewrite the safe projection, acquire credentials, fetch source, write to the Site repository, or prove public reachability. The materializer receipt must remain `NONE_COPY_ONLY`, exact-byte preserving, non-recalculating, non-recovery, and `live_publication_observed=false`.
+
+## Next
+
+Pass Test Readiness and merge. Then reconcile canonical child state. Authentic materialization remains unproven until a resident ECE cycle runs with an already-local served Site root and retained materialization receipt, followed by independent public page observation.

--- a/tests/test_ece_site_materializer_binding.py
+++ b/tests/test_ece_site_materializer_binding.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("ece_runner", ROOT / "app" / "run_ece_periodic_evaluation.py")
+MOD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MOD)
+
+
+def base_result(root: Path) -> dict:
+    output = root / "receipts" / "ecosystem-continuity"
+    output.mkdir(parents=True)
+    result = {
+        "schema": "stegverse.healer-ecosystem-continuity-cycle/v1",
+        "state": "COMPLETE",
+        "site_projection_ref": str((output / "site-projection.latest.json").resolve()),
+        "site_projection_sha256": "a" * 64,
+        "authority_effect": "NONE",
+        "execution": [],
+    }
+    (output / "cycle.latest.json").write_text(json.dumps(result), encoding="utf-8")
+    return result
+
+
+class SiteMaterializerBindingTests(unittest.TestCase):
+    def test_missing_served_root_is_honest_not_bound_not_failure(self):
+        with tempfile.TemporaryDirectory() as td, patch.dict(os.environ, {}, clear=True):
+            runtime = Path(td)
+            result = MOD.bind_site_materialization(base_result(runtime), {}, runtime)
+            self.assertEqual(result["state"], "COMPLETE")
+            self.assertEqual(result["site_materialization_state"], "NOT_BOUND")
+            self.assertFalse(result["site_live_publication_observed"])
+            retained = json.loads((runtime / "receipts" / "ecosystem-continuity" / "cycle.latest.json").read_text())
+            self.assertEqual(retained["site_materialization_state"], "NOT_BOUND")
+
+    def test_explicit_served_root_requires_local_site_source(self):
+        with tempfile.TemporaryDirectory() as td, patch.dict(os.environ, {"STEGVERSE_SITE_SERVED_ROOT": str(Path(td) / "served")}, clear=True):
+            runtime = Path(td) / "runtime"
+            result = MOD.bind_site_materialization(base_result(runtime), {}, runtime)
+            self.assertEqual(result["state"], "BLOCKED")
+            self.assertEqual(result["outcome"], "ECE_SITE_LOCAL_SOURCE_MISSING_FOR_MATERIALIZER")
+
+    def test_noncomplete_cycle_is_not_materialized(self):
+        with tempfile.TemporaryDirectory() as td, patch.dict(os.environ, {"STEGVERSE_SITE_SERVED_ROOT": str(Path(td) / "served")}, clear=True):
+            result = {"state": "BLOCKED", "outcome": "UPSTREAM_BLOCK"}
+            self.assertIs(MOD.bind_site_materialization(result, {}, Path(td)), result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the Healer-side source binding for SITE-ECE-CURRENT-PROJECTION-MATERIALIZER-001 / COSV 71000000102000. After the existing SDK diagnostic -> ECE -> Master Records -> Healer intake -> Site-safe projection cycle completes, the runner optionally invokes the merged Site copy-only materializer when STEGVERSE_SITE_SERVED_ROOT is locally bound. No binding is recorded honestly as NOT_BOUND without failing ECE. An explicit binding fails closed on missing Site source, projection/materializer error, or materialization receipt drift. A successful copy is only MATERIALIZED_PENDING_PUBLIC_OBSERVATION; live publication and recovery remain false. No source acquisition, continuity recalculation, credential authority, or second scheduler is introduced.